### PR TITLE
Add color wheel for choosing text color

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -16,6 +16,7 @@ hotline::object!({
     pub struct Application {
         window_manager: Option<WindowManager>,
         code_editor: Option<CodeEditor>,
+        color_wheel: Option<ColorWheel>,
         gpu_renderer: Option<GPURenderer>,
         gpu_atlases: Vec<AtlasData>,
         gpu_commands: Vec<RenderCommand>,
@@ -59,6 +60,15 @@ hotline::object!({
                     wm.add_rect(editor_rect.clone());
                 }
                 editor.set_rect(editor_rect);
+            }
+
+            // Create color wheel
+            self.color_wheel = Some(ColorWheel::new());
+            if let Some(ref mut wheel) = self.color_wheel {
+                let rect = Rect::new();
+                let mut r_ref = rect.clone();
+                r_ref.initialize(50.0, 400.0, 120.0, 120.0);
+                wheel.set_rect(rect);
             }
 
             Ok(())
@@ -107,6 +117,13 @@ hotline::object!({
                             }
                             if let Some(ref mut editor) = self.code_editor {
                                 editor.handle_mouse_down(x as f64, y as f64);
+                            }
+                            if let Some(ref mut wheel) = self.color_wheel {
+                                if let Some(color) = wheel.handle_mouse_down(x as f64, y as f64) {
+                                    if let Some(ref mut editor) = self.code_editor {
+                                        editor.update_text_color(color);
+                                    }
+                                }
                             }
                         }
                         Event::MouseButtonUp { mouse_btn: MouseButton::Left, x, y, .. } => {
@@ -206,6 +223,9 @@ hotline::object!({
                 if let Some(ref mut editor) = self.code_editor {
                     editor.render(buffer, 800, 600, pitch as i64);
                 }
+                if let Some(ref mut wheel) = self.color_wheel {
+                    wheel.render(buffer, 800, 600, pitch as i64);
+                }
             })?;
             Ok(())
         }
@@ -240,6 +260,9 @@ hotline::object!({
                 // Render code editor
                 if let Some(ref mut editor) = self.code_editor {
                     editor.render(buffer, 800, 600, pitch as i64);
+                }
+                if let Some(ref mut wheel) = self.color_wheel {
+                    wheel.render(buffer, 800, 600, pitch as i64);
                 }
 
                 for y in 0..600 {

--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -10,6 +10,9 @@ hotline::object!({
         focused: bool,
         highlight: Option<HighlightLens>,
         text_renderer: Option<TextRenderer>,
+        #[setter]
+        #[default((255, 255, 255, 255))]
+        text_color: (u8, u8, u8, u8),
     }
 
     impl CodeEditor {
@@ -24,7 +27,16 @@ hotline::object!({
             }
 
             if self.text_renderer.is_none() {
-                self.text_renderer = Some(TextRenderer::new());
+                let mut tr = TextRenderer::new();
+                tr.set_color(self.text_color);
+                self.text_renderer = Some(tr);
+            }
+        }
+
+        pub fn update_text_color(&mut self, color: (u8, u8, u8, u8)) {
+            self.text_color = color;
+            if let Some(ref mut tr) = self.text_renderer {
+                tr.set_color(color);
             }
         }
 
@@ -100,7 +112,7 @@ hotline::object!({
                 let line_height = 14.0;
 
                 if let Some(ref mut tr) = self.text_renderer {
-                    tr.set_color((255, 255, 255, 255));
+                    tr.set_color(self.text_color);
                     for line in self.text.split('\n') {
                         tr.set_text(line.to_string());
                         tr.set_x(x + 10.0);

--- a/objects/ColorWheel/Cargo.toml
+++ b/objects/ColorWheel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ColorWheel"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/ColorWheel/src/lib.rs
+++ b/objects/ColorWheel/src/lib.rs
@@ -1,0 +1,96 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Clone, Default)]
+    pub struct ColorWheel {
+        rect: Option<Rect>,
+        #[setter]
+        #[default((255, 255, 255, 255))]
+        selected_color: (u8, u8, u8, u8),
+    }
+
+    impl ColorWheel {
+        pub fn set_rect(&mut self, rect: Rect) {
+            self.rect = Some(rect);
+        }
+
+        pub fn selected_color(&mut self) -> (u8, u8, u8, u8) {
+            self.selected_color
+        }
+
+        pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> Option<(u8, u8, u8, u8)> {
+            if let Some(ref mut r) = self.rect {
+                if r.contains_point(x, y) {
+                    let (rx, ry, w, h) = r.bounds();
+                    let cx = rx + w / 2.0;
+                    let cy = ry + h / 2.0;
+                    let radius = w.min(h) / 2.0;
+                    let dx = x - cx;
+                    let dy = y - cy;
+                    let dist = (dx * dx + dy * dy).sqrt();
+                    if dist <= radius {
+                        let h = (dy.atan2(dx) + std::f64::consts::PI) / (2.0 * std::f64::consts::PI);
+                        let s = dist / radius;
+                        let v = 1.0;
+                        let (r_col, g_col, b_col) = Self::hsv_to_rgb(h, s, v);
+                        self.selected_color = (b_col, g_col, r_col, 255);
+                        return Some(self.selected_color);
+                    }
+                }
+            }
+            None
+        }
+
+        fn hsv_to_rgb(h: f64, s: f64, v: f64) -> (u8, u8, u8) {
+            let i = (h * 6.0).floor();
+            let f = h * 6.0 - i;
+            let p = v * (1.0 - s);
+            let q = v * (1.0 - f * s);
+            let t = v * (1.0 - (1.0 - f) * s);
+            let (r, g, b) = match i as i32 % 6 {
+                0 => (v, t, p),
+                1 => (q, v, p),
+                2 => (p, v, t),
+                3 => (p, q, v),
+                4 => (t, p, v),
+                _ => (v, p, q),
+            };
+            ((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if let Some(ref mut rect) = self.rect {
+                let (x, y, w, h) = rect.bounds();
+                let cx = x + w / 2.0;
+                let cy = y + h / 2.0;
+                let radius = w.min(h) / 2.0;
+
+                let x_start = x.max(0.0) as u32;
+                let y_start = y.max(0.0) as u32;
+                let x_end = (x + w).min(buffer_width as f64) as u32;
+                let y_end = (y + h).min(buffer_height as f64) as u32;
+
+                for py in y_start..y_end {
+                    for px in x_start..x_end {
+                        let dx = px as f64 + 0.5 - cx;
+                        let dy = py as f64 + 0.5 - cy;
+                        let dist = (dx * dx + dy * dy).sqrt();
+                        if dist <= radius {
+                            let h_val = (dy.atan2(dx) + std::f64::consts::PI) / (2.0 * std::f64::consts::PI);
+                            let s_val = dist / radius;
+                            let v_val = 1.0;
+                            let (r_col, g_col, b_col) = Self::hsv_to_rgb(h_val, s_val, v_val);
+                            let offset = (py * (pitch as u32) + px * 4) as usize;
+                            if offset + 3 < buffer.len() {
+                                buffer[offset] = b_col;
+                                buffer[offset + 1] = g_col;
+                                buffer[offset + 2] = r_col;
+                                buffer[offset + 3] = 255;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- create new `ColorWheel` object to pick colors
- allow `CodeEditor` text color to be updated
- render and handle the color wheel in `Application`

## Testing
- `cargo fmt` *(fails: `cargo-fmt` not installed initially; installed rustfmt via rustup and ran again)*
- `cargo run --bin runtime --release` *(fails: libraries not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_684304bcdd6c8325883b9b4aac86d857