### PR TITLE
Add rectangle resizing support

### DIFF
--- a/objects/HighlightLens/src/lib.rs
+++ b/objects/HighlightLens/src/lib.rs
@@ -6,6 +6,9 @@ hotline::object!({
         #[setter]
         #[default((0, 255, 0, 255))]
         highlight_color: (u8, u8, u8, u8), // BGRA
+        #[setter]
+        #[default(false)]
+        show_handles: bool,
     }
 
     impl HighlightLens {
@@ -55,6 +58,39 @@ hotline::object!({
                         buffer[right_offset + 1] = g;
                         buffer[right_offset + 2] = r;
                         buffer[right_offset + 3] = a;
+                    }
+                }
+
+                if self.show_handles {
+                    let handle = 6u32;
+                    let half = handle / 2;
+                    let mid_x = (x_start + x_end) / 2;
+                    let mid_y = (y_start + y_end) / 2;
+                    let mut positions = vec![
+                        (x_start, y_start),
+                        (x_end.saturating_sub(handle), y_start),
+                        (x_start, y_end.saturating_sub(handle)),
+                        (x_end.saturating_sub(handle), y_end.saturating_sub(handle)),
+                        (x_start, mid_y.saturating_sub(half)),
+                        (x_end.saturating_sub(handle), mid_y.saturating_sub(half)),
+                        (mid_x.saturating_sub(half), y_start),
+                        (mid_x.saturating_sub(half), y_end.saturating_sub(handle)),
+                    ];
+
+                    for (hx, hy) in positions.drain(..) {
+                        for py in hy..hy + handle {
+                            for px in hx..hx + handle {
+                                if px < buffer_width as u32 && py < buffer_height as u32 {
+                                    let off = (py * (pitch as u32) + px * 4) as usize;
+                                    if off + 3 < buffer.len() {
+                                        buffer[off] = b;
+                                        buffer[off + 1] = g;
+                                        buffer[off + 2] = r;
+                                        buffer[off + 3] = a;
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/objects/Rect/src/lib.rs
+++ b/objects/Rect/src/lib.rs
@@ -32,6 +32,13 @@ hotline::object!({
             self.y += dy;
         }
 
+        pub fn resize(&mut self, x: f64, y: f64, width: f64, height: f64) {
+            self.x = x;
+            self.y = y;
+            self.width = width;
+            self.height = height;
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             // Draw rectangle by setting pixels
             let x_start = (self.x as i32).max(0) as u32;

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -11,6 +11,24 @@ hotline::object!({
         drag_offset_x: f64,
         drag_offset_y: f64,
         drag_start: Option<(f64, f64)>,
+        resizing: bool,
+        resize_dir: ResizeDir,
+        resize_start: Option<(f64, f64)>,
+        resize_orig: Option<(f64, f64, f64, f64)>,
+    }
+
+    #[derive(Clone, Copy, PartialEq, Default)]
+    enum ResizeDir {
+        #[default]
+        None,
+        Left,
+        Right,
+        Top,
+        Bottom,
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight,
     }
 
     impl WindowManager {
@@ -40,6 +58,10 @@ hotline::object!({
             self.selected = None;
             self.highlight_lens = None;
             self.dragging = false;
+            self.resizing = false;
+            self.resize_dir = ResizeDir::None;
+            self.resize_start = None;
+            self.resize_orig = None;
         }
 
         pub fn set_drag_offset(&mut self, x: f64, y: f64) {
@@ -80,13 +102,38 @@ hotline::object!({
             // First check for hits
             let mut hit_index = None;
             let mut hit_position = (0.0, 0.0);
+            let mut resize_dir = ResizeDir::None;
 
             for (i, rect_handle) in self.rects.iter_mut().enumerate().rev() {
                 // Check if this rect contains the point
-                if rect_handle.contains_point(x, y) {
-                    hit_index = Some(i);
+                let (rx, ry, rw, rh) = rect_handle.bounds();
+                let margin = 5.0;
+                let inside = rect_handle.contains_point(x, y);
+                let near_left = (x - rx).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                let near_right = (x - (rx + rw)).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                let near_top = (y - ry).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+                let near_bottom = (y - (ry + rh)).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
 
-                    // Get rect position for offset calculation
+                if near_left && near_top {
+                    resize_dir = ResizeDir::TopLeft;
+                } else if near_right && near_top {
+                    resize_dir = ResizeDir::TopRight;
+                } else if near_left && near_bottom {
+                    resize_dir = ResizeDir::BottomLeft;
+                } else if near_right && near_bottom {
+                    resize_dir = ResizeDir::BottomRight;
+                } else if near_left {
+                    resize_dir = ResizeDir::Left;
+                } else if near_right {
+                    resize_dir = ResizeDir::Right;
+                } else if near_top {
+                    resize_dir = ResizeDir::Top;
+                } else if near_bottom {
+                    resize_dir = ResizeDir::Bottom;
+                }
+
+                if resize_dir != ResizeDir::None || inside {
+                    hit_index = Some(i);
                     hit_position = rect_handle.position();
                     break;
                 }
@@ -98,15 +145,22 @@ hotline::object!({
             if let Some(index) = hit_index {
                 // Found a hit - select it
                 let rect_handle = &self.rects[index];
-
-                // Calculate drag offset from click position to rect position
-                self.drag_offset_x = hit_position.0 - x;
-                self.drag_offset_y = hit_position.1 - y;
                 self.selected = Some(rect_handle.clone());
-                self.dragging = true;
 
                 // Create HighlightLens for selected rect
                 self.highlight_lens = Some(HighlightLens::new().with_target(rect_handle));
+
+                if resize_dir != ResizeDir::None {
+                    self.resizing = true;
+                    self.resize_dir = resize_dir;
+                    self.resize_start = Some((x, y));
+                    self.resize_orig = Some(rect_handle.bounds());
+                } else {
+                    // Calculate drag offset from click position to rect position
+                    self.drag_offset_x = hit_position.0 - x;
+                    self.drag_offset_y = hit_position.1 - y;
+                    self.dragging = true;
+                }
             } else {
                 // No hit - start rect creation
                 self.drag_start = Some((x, y));
@@ -114,7 +168,12 @@ hotline::object!({
         }
 
         pub fn handle_mouse_up(&mut self, x: f64, y: f64) {
-            if self.dragging {
+            if self.resizing {
+                self.resizing = false;
+                self.resize_dir = ResizeDir::None;
+                self.resize_start = None;
+                self.resize_orig = None;
+            } else if self.dragging {
                 self.stop_dragging();
             } else if let Some((start_x, start_y)) = self.drag_start {
                 // Create a new rect directly
@@ -148,6 +207,67 @@ hotline::object!({
 
                     // Move the rect
                     selected_handle.move_by(dx, dy);
+                }
+            } else if self.resizing {
+                if let (
+                    Some(ref mut selected_handle),
+                    Some((start_x, start_y)),
+                    Some((orig_x, orig_y, orig_w, orig_h)),
+                ) = (self.selected.as_mut(), self.resize_start, self.resize_orig)
+                {
+                    let dx = x - start_x;
+                    let dy = y - start_y;
+                    let mut new_x = orig_x;
+                    let mut new_y = orig_y;
+                    let mut new_w = orig_w;
+                    let mut new_h = orig_h;
+
+                    match self.resize_dir {
+                        ResizeDir::Left => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                        }
+                        ResizeDir::Right => {
+                            new_w = orig_w + dx;
+                        }
+                        ResizeDir::Top => {
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::Bottom => {
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::TopLeft => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::TopRight => {
+                            new_w = orig_w + dx;
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::BottomLeft => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::BottomRight => {
+                            new_w = orig_w + dx;
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::None => {}
+                    }
+
+                    if new_w < 1.0 {
+                        new_w = 1.0;
+                    }
+                    if new_h < 1.0 {
+                        new_h = 1.0;
+                    }
+
+                    selected_handle.resize(new_x, new_y, new_w, new_h);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- allow resizing rectangles by dragging edges or corners
- maintain resize state in WindowManager
- add `resize` method to Rect

## Testing
- `cargo run --bin runtime --release` *(fails: library 'libApplication' not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_684304d6bb4083258f61f96aee7095c7