### PR TITLE
Add rotation for rectangles

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -135,6 +135,11 @@ hotline::object!({
                                 }
                             }
                         }
+                        Event::KeyDown { keycode: Some(Keycode::R), .. } => {
+                            if let Some(ref mut wm) = self.window_manager {
+                                wm.rotate_selected(0.1);
+                            }
+                        }
                         Event::KeyDown { keycode: Some(Keycode::S), keymod, .. } => {
                             // Check for Cmd+S (Mac) or Ctrl+S (others)
                             #[cfg(target_os = "macos")]

--- a/objects/HighlightLens/src/lib.rs
+++ b/objects/HighlightLens/src/lib.rs
@@ -9,53 +9,51 @@ hotline::object!({
     }
 
     impl HighlightLens {
-        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
-            if let Some(ref mut target) = self.target {
-                // Only draw highlight border (rect is already rendered by WindowManager)
-                // Now just call bounds() directly!
-                let (x, y, width, height) = target.bounds();
-
-                let x_start = (x as i32).max(0) as u32;
-                let y_start = (y as i32).max(0) as u32;
-                let x_end = ((x + width) as i32).min(buffer_width as i32) as u32;
-                let y_end = ((y + height) as i32).min(buffer_height as i32) as u32;
-
-                let (b, g, r, a) = self.highlight_color;
-
-                // Top and bottom borders
-                for x in x_start..x_end {
-                    let top_offset = (y_start * (pitch as u32) + x * 4) as usize;
-                    let bottom_offset = ((y_end - 1) * (pitch as u32) + x * 4) as usize;
-                    if top_offset + 3 < buffer.len() {
-                        buffer[top_offset] = b;
-                        buffer[top_offset + 1] = g;
-                        buffer[top_offset + 2] = r;
-                        buffer[top_offset + 3] = a;
-                    }
-                    if bottom_offset + 3 < buffer.len() {
-                        buffer[bottom_offset] = b;
-                        buffer[bottom_offset + 1] = g;
-                        buffer[bottom_offset + 2] = r;
-                        buffer[bottom_offset + 3] = a;
+        fn draw_line(
+            buffer: &mut [u8],
+            bw: i64,
+            bh: i64,
+            pitch: i64,
+            b: u8,
+            g: u8,
+            r: u8,
+            a: u8,
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+        ) {
+            let dx = x1 - x0;
+            let dy = y1 - y0;
+            let steps = dx.abs().max(dy.abs()) as i64;
+            if steps == 0 {
+                return;
+            }
+            for i in 0..=steps {
+                let t = i as f64 / steps as f64;
+                let x = x0 + dx * t;
+                let y = y0 + dy * t;
+                if x >= 0.0 && x < bw as f64 && y >= 0.0 && y < bh as f64 {
+                    let offset = (y as i64 * pitch + x as i64 * 4) as usize;
+                    if offset + 3 < buffer.len() {
+                        buffer[offset] = b;
+                        buffer[offset + 1] = g;
+                        buffer[offset + 2] = r;
+                        buffer[offset + 3] = a;
                     }
                 }
+            }
+        }
 
-                // Left and right borders
-                for y in y_start..y_end {
-                    let left_offset = (y * (pitch as u32) + x_start * 4) as usize;
-                    let right_offset = (y * (pitch as u32) + (x_end - 1) * 4) as usize;
-                    if left_offset + 3 < buffer.len() {
-                        buffer[left_offset] = b;
-                        buffer[left_offset + 1] = g;
-                        buffer[left_offset + 2] = r;
-                        buffer[left_offset + 3] = a;
-                    }
-                    if right_offset + 3 < buffer.len() {
-                        buffer[right_offset] = b;
-                        buffer[right_offset + 1] = g;
-                        buffer[right_offset + 2] = r;
-                        buffer[right_offset + 3] = a;
-                    }
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if let Some(ref mut target) = self.target {
+                let corners = target.corners();
+                let (b, g, r, a) = self.highlight_color;
+
+                for i in 0..4 {
+                    let (x0, y0) = corners[i];
+                    let (x1, y1) = corners[(i + 1) % 4];
+                    Self::draw_line(buffer, buffer_width, buffer_height, pitch, b, g, r, a, x0, y0, x1, y1);
                 }
             }
         }

--- a/objects/Rect/src/lib.rs
+++ b/objects/Rect/src/lib.rs
@@ -5,6 +5,8 @@ hotline::object!({
         y: f64,
         width: f64,
         height: f64,
+        #[default(0.0)]
+        rotation: f64, // radians
     }
 
     impl Rect {
@@ -13,10 +15,17 @@ hotline::object!({
             self.y = y;
             self.width = width;
             self.height = height;
+            self.rotation = 0.0;
         }
 
         pub fn contains_point(&mut self, point_x: f64, point_y: f64) -> bool {
-            point_x >= self.x && point_x <= self.x + self.width && point_y >= self.y && point_y <= self.y + self.height
+            let (cx, cy) = self.center();
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+            let dx = point_x - cx;
+            let dy = point_y - cy;
+            let rx = dx * cos_r + dy * sin_r;
+            let ry = -dx * sin_r + dy * cos_r;
+            rx.abs() <= self.width / 2.0 && ry.abs() <= self.height / 2.0
         }
 
         pub fn position(&mut self) -> (f64, f64) {
@@ -24,7 +33,14 @@ hotline::object!({
         }
 
         pub fn bounds(&mut self) -> (f64, f64, f64, f64) {
-            (self.x, self.y, self.width, self.height)
+            let corners = self.corners();
+            let xs = [corners[0].0, corners[1].0, corners[2].0, corners[3].0];
+            let ys = [corners[0].1, corners[1].1, corners[2].1, corners[3].1];
+            let min_x = xs.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max_x = xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            let min_y = ys.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max_y = ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            (min_x, min_y, max_x - min_x, max_y - min_y)
         }
 
         pub fn move_by(&mut self, dx: f64, dy: f64) {
@@ -32,22 +48,55 @@ hotline::object!({
             self.y += dy;
         }
 
-        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
-            // Draw rectangle by setting pixels
-            let x_start = (self.x as i32).max(0) as u32;
-            let y_start = (self.y as i32).max(0) as u32;
-            let x_end = ((self.x + self.width) as i32).min(buffer_width as i32) as u32;
-            let y_end = ((self.y + self.height) as i32).min(buffer_height as i32) as u32;
+        pub fn set_rotation(&mut self, angle: f64) {
+            self.rotation = angle;
+        }
 
-            // Draw filled rectangle
+        pub fn rotation(&mut self) -> f64 {
+            self.rotation
+        }
+
+        pub fn center(&mut self) -> (f64, f64) {
+            (self.x + self.width / 2.0, self.y + self.height / 2.0)
+        }
+
+        pub fn corners(&mut self) -> [(f64, f64); 4] {
+            let (cx, cy) = self.center();
+            let hw = self.width / 2.0;
+            let hh = self.height / 2.0;
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+            let mut rot = |dx: f64, dy: f64| -> (f64, f64) {
+                let rx = dx * cos_r - dy * sin_r;
+                let ry = dx * sin_r + dy * cos_r;
+                (cx + rx, cy + ry)
+            };
+            [rot(-hw, -hh), rot(hw, -hh), rot(hw, hh), rot(-hw, hh)]
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            let (bx, by, bw, bh) = self.bounds();
+            let x_start = (bx as i32).max(0) as u32;
+            let y_start = (by as i32).max(0) as u32;
+            let x_end = ((bx + bw) as i32).min(buffer_width as i32) as u32;
+            let y_end = ((by + bh) as i32).min(buffer_height as i32) as u32;
+
+            let (cx, cy) = self.center();
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+
             for y in y_start..y_end {
                 for x in x_start..x_end {
-                    let offset = (y * (pitch as u32) + x * 4) as usize;
-                    if offset + 3 < buffer.len() {
-                        buffer[offset] = 120; // B
-                        buffer[offset + 1] = 0; // G
-                        buffer[offset + 2] = 0; // R
-                        buffer[offset + 3] = 255; // A
+                    let dx = x as f64 - cx;
+                    let dy = y as f64 - cy;
+                    let rx = dx * cos_r + dy * sin_r;
+                    let ry = -dx * sin_r + dy * cos_r;
+                    if rx.abs() <= self.width / 2.0 && ry.abs() <= self.height / 2.0 {
+                        let offset = (y * (pitch as u32) + x * 4) as usize;
+                        if offset + 3 < buffer.len() {
+                            buffer[offset] = 120; // B
+                            buffer[offset + 1] = 0; // G
+                            buffer[offset + 2] = 0; // R
+                            buffer[offset + 3] = 255; // A
+                        }
                     }
                 }
             }

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -152,6 +152,13 @@ hotline::object!({
             }
         }
 
+        pub fn rotate_selected(&mut self, angle: f64) {
+            if let Some(ref mut selected_handle) = self.selected {
+                let new_rot = selected_handle.rotation() + angle;
+                selected_handle.set_rotation(new_rot);
+            }
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             // Render all rects
             for rect_handle in &mut self.rects {


### PR DESCRIPTION
## Summary
- add rotation field and logic for `Rect`
- rotate highlight borders using corner calculations
- allow rotating selected rectangle via WindowManager
- hook up `R` key in `Application` to rotate selection

## Testing
- `cargo build --release`
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_6843306e278c83258d1c5adfa3c1515d