### PR TITLE
Add scroll clipping to code editor

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -119,6 +119,13 @@ hotline::object!({
                                 wm.handle_mouse_motion(x as f64, y as f64);
                             }
                         }
+                        Event::MouseWheel { y, .. } => {
+                            if let Some(ref mut editor) = self.code_editor {
+                                if editor.is_focused() {
+                                    editor.scroll_by(-y as f64 * 20.0);
+                                }
+                            }
+                        }
                         Event::TextInput { text, .. } => {
                             if let Some(ref mut editor) = self.code_editor {
                                 if editor.is_focused() {

--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -10,6 +10,9 @@ hotline::object!({
         focused: bool,
         highlight: Option<HighlightLens>,
         text_renderer: Option<TextRenderer>,
+        #[setter]
+        #[default(0.0)]
+        scroll_offset: f64,
     }
 
     impl CodeEditor {
@@ -71,6 +74,15 @@ hotline::object!({
             }
         }
 
+        pub fn scroll_by(&mut self, delta: f64) {
+            if let Some(ref mut rect) = self.rect {
+                let line_height = 14.0;
+                let total_height = self.text.lines().count() as f64 * line_height;
+                let max_offset = (total_height - rect.bounds().3).max(0.0);
+                self.scroll_offset = (self.scroll_offset + delta).max(0.0).min(max_offset);
+            }
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             if let Some(registry) = self.get_registry() {
                 ::hotline::set_library_registry(registry);
@@ -78,9 +90,10 @@ hotline::object!({
 
             if let Some(ref mut rect) = self.rect {
                 let (x, y, w, h) = rect.bounds();
+                let scroll_bar_width = 8.0;
                 let x_start = x.max(0.0) as u32;
                 let y_start = y.max(0.0) as u32;
-                let x_end = (x + w).min(buffer_width as f64) as u32;
+                let x_end = (x + w - scroll_bar_width).min(buffer_width as f64) as u32;
                 let y_end = (y + h).min(buffer_height as f64) as u32;
 
                 // Draw background
@@ -96,17 +109,42 @@ hotline::object!({
                     }
                 }
 
-                let mut cursor_y = y + 10.0;
                 let line_height = 14.0;
+
+                let mut cursor_y = y + 10.0 - self.scroll_offset;
 
                 if let Some(ref mut tr) = self.text_renderer {
                     tr.set_color((255, 255, 255, 255));
                     for line in self.text.split('\n') {
-                        tr.set_text(line.to_string());
-                        tr.set_x(x + 10.0);
-                        tr.set_y(cursor_y);
-                        tr.render(buffer, buffer_width, buffer_height, pitch);
+                        if cursor_y + line_height >= y && cursor_y <= y + h {
+                            tr.set_text(line.to_string());
+                            tr.set_x(x + 10.0);
+                            tr.set_y(cursor_y);
+                            tr.render(buffer, buffer_width, buffer_height, pitch);
+                        }
                         cursor_y += line_height;
+                    }
+                }
+
+                let total_height = self.text.lines().count() as f64 * line_height;
+                if total_height > h {
+                    let bar_height = (h / total_height) * h;
+                    let bar_y = y + (self.scroll_offset / total_height) * h;
+                    let bar_x_start = (x + w - scroll_bar_width).max(0.0) as u32;
+                    let bar_x_end = (x + w).min(buffer_width as f64) as u32;
+                    let bar_y_start = bar_y.max(0.0) as u32;
+                    let bar_y_end = (bar_y + bar_height).min(buffer_height as f64).min(y + h) as u32;
+
+                    for py in bar_y_start..bar_y_end {
+                        for px in bar_x_start..bar_x_end {
+                            let offset = (py * (pitch as u32) + px * 4) as usize;
+                            if offset + 3 < buffer.len() {
+                                buffer[offset] = 80;
+                                buffer[offset + 1] = 80;
+                                buffer[offset + 2] = 80;
+                                buffer[offset + 3] = 255;
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- make `CodeEditor` clip rendered text and expose a scroll offset
- render a simple scrollbar
- allow scrolling via mouse wheel in `Application`

## Testing
- `cargo build --release`
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_68432ff9439c8325b40db874c97c0fc1