### PR TITLE
Add Circle selection and context menu

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -16,9 +16,14 @@ hotline::object!({
     pub struct Application {
         window_manager: Option<WindowManager>,
         code_editor: Option<CodeEditor>,
+        color_wheel: Option<ColorWheel>,
         gpu_renderer: Option<GPURenderer>,
         gpu_atlases: Vec<AtlasData>,
         gpu_commands: Vec<RenderCommand>,
+        fps_counter: Option<TextRenderer>,
+        frame_times: std::collections::VecDeque<std::time::Instant>,
+        last_fps_update: Option<std::time::Instant>,
+        current_fps: f64,
     }
 
     impl Application {
@@ -61,6 +66,29 @@ hotline::object!({
                 editor.set_rect(editor_rect);
             }
 
+            // Create color wheel
+            self.color_wheel = Some(ColorWheel::new());
+            if let Some(ref mut wheel) = self.color_wheel {
+                let rect = Rect::new();
+                let mut r_ref = rect.clone();
+                r_ref.initialize(50.0, 400.0, 120.0, 120.0);
+                wheel.set_rect(rect);
+            }
+
+            // Create FPS counter
+            self.fps_counter = Some(TextRenderer::new());
+            if let Some(ref mut fps) = self.fps_counter {
+                fps.set_x(10.0);
+                fps.set_y(10.0);
+                fps.set_color((0, 255, 0, 255)); // Green color (BGRA)
+                fps.set_text("FPS: 0".to_string());
+            }
+
+            // Initialize FPS tracking
+            self.frame_times = std::collections::VecDeque::with_capacity(120);
+            self.last_fps_update = Some(std::time::Instant::now());
+            self.current_fps = 0.0;
+
             Ok(())
         }
 
@@ -72,6 +100,7 @@ hotline::object!({
                 .window("hotline - direct calls", 800, 600)
                 .position_centered()
                 .allow_highdpi()
+                .resizable()
                 .build()
                 .map_err(|e| e.to_string())?;
 
@@ -92,6 +121,34 @@ hotline::object!({
             }
 
             'running: loop {
+                // Track frame time
+                let now = std::time::Instant::now();
+                self.frame_times.push_back(now);
+
+                // Remove old frame times (keep last 2 seconds)
+                while let Some(front) = self.frame_times.front() {
+                    if now.duration_since(*front).as_secs_f64() > 2.0 {
+                        self.frame_times.pop_front();
+                    } else {
+                        break;
+                    }
+                }
+
+                // Update FPS every 100ms
+                if let Some(last_update) = self.last_fps_update {
+                    if now.duration_since(last_update).as_millis() >= 100 {
+                        if self.frame_times.len() > 1 {
+                            let duration = now.duration_since(*self.frame_times.front().unwrap()).as_secs_f64();
+                            self.current_fps = (self.frame_times.len() - 1) as f64 / duration;
+
+                            if let Some(ref mut fps) = self.fps_counter {
+                                fps.set_text(format!("FPS: {:.1}", self.current_fps));
+                            }
+                        }
+                        self.last_fps_update = Some(now);
+                    }
+                }
+
                 canvas.set_draw_color(Color::RGB(0, 0, 0));
                 canvas.clear();
 
@@ -108,6 +165,18 @@ hotline::object!({
                             if let Some(ref mut editor) = self.code_editor {
                                 editor.handle_mouse_down(x as f64, y as f64);
                             }
+                            if let Some(ref mut wheel) = self.color_wheel {
+                                if let Some(color) = wheel.handle_mouse_down(x as f64, y as f64) {
+                                    if let Some(ref mut editor) = self.code_editor {
+                                        editor.update_text_color(color);
+                                    }
+                                }
+                            }
+                        }
+                        Event::MouseButtonDown { mouse_btn: MouseButton::Right, x, y, .. } => {
+                            if let Some(ref mut wm) = self.window_manager {
+                                wm.handle_right_click(x as f64, y as f64);
+                            }
                         }
                         Event::MouseButtonUp { mouse_btn: MouseButton::Left, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
@@ -117,6 +186,13 @@ hotline::object!({
                         Event::MouseMotion { x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_motion(x as f64, y as f64);
+                            }
+                        }
+                        Event::MouseWheel { y, .. } => {
+                            if let Some(ref mut editor) = self.code_editor {
+                                if editor.is_focused() {
+                                    editor.scroll_by(-y as f64 * 20.0);
+                                }
                             }
                         }
                         Event::TextInput { text, .. } => {
@@ -133,6 +209,11 @@ hotline::object!({
                                 if editor.is_focused() {
                                     editor.backspace();
                                 }
+                            }
+                        }
+                        Event::KeyDown { keycode: Some(Keycode::R), .. } => {
+                            if let Some(ref mut wm) = self.window_manager {
+                                wm.rotate_selected(0.1);
                             }
                         }
                         Event::KeyDown { keycode: Some(Keycode::S), keymod, .. } => {
@@ -206,6 +287,15 @@ hotline::object!({
                 if let Some(ref mut editor) = self.code_editor {
                     editor.render(buffer, 800, 600, pitch as i64);
                 }
+
+                if let Some(ref mut wheel) = self.color_wheel {
+                    wheel.render(buffer, 800, 600, pitch as i64);
+                }
+
+                // Render FPS counter
+                if let Some(ref mut fps) = self.fps_counter {
+                    fps.render(buffer, 800, 600, pitch as i64);
+                }
             })?;
             Ok(())
         }
@@ -240,6 +330,14 @@ hotline::object!({
                 // Render code editor
                 if let Some(ref mut editor) = self.code_editor {
                     editor.render(buffer, 800, 600, pitch as i64);
+                }
+                if let Some(ref mut wheel) = self.color_wheel {
+                    wheel.render(buffer, 800, 600, pitch as i64);
+                }
+
+                // Render FPS counter
+                if let Some(ref mut fps) = self.fps_counter {
+                    fps.render(buffer, 800, 600, pitch as i64);
                 }
 
                 for y in 0..600 {

--- a/objects/Circle/Cargo.toml
+++ b/objects/Circle/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2024"
+name = "Circle"
+version = "0.1.0"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = {path = "../../hotline"}
+# do not add additional dependencies here

--- a/objects/Circle/src/lib.rs
+++ b/objects/Circle/src/lib.rs
@@ -1,0 +1,74 @@
+hotline::object!({
+    #[derive(Default, Clone)]
+    pub struct Circle {
+        x: f64,
+        y: f64,
+        radius: f64,
+    }
+
+    impl Circle {
+        pub fn initialize(&mut self, x: f64, y: f64, radius: f64) {
+            self.x = x;
+            self.y = y;
+            self.radius = radius;
+        }
+
+        pub fn contains_point(&mut self, point_x: f64, point_y: f64) -> bool {
+            let dx = point_x - self.x;
+            let dy = point_y - self.y;
+            dx * dx + dy * dy <= self.radius * self.radius
+        }
+
+        pub fn position(&mut self) -> (f64, f64) {
+            (self.x, self.y)
+        }
+
+        pub fn radius(&mut self) -> f64 {
+            self.radius
+        }
+
+        pub fn bounds(&mut self) -> (f64, f64, f64, f64) {
+            (self.x - self.radius, self.y - self.radius, self.radius * 2.0, self.radius * 2.0)
+        }
+
+        pub fn corners(&mut self) -> [(f64, f64); 4] {
+            let (x, y, w, h) = self.bounds();
+            [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
+        }
+
+        pub fn move_by(&mut self, dx: f64, dy: f64) {
+            self.x += dx;
+            self.y += dy;
+        }
+
+        pub fn resize(&mut self, x: f64, y: f64, width: f64, height: f64) {
+            let r = (width.max(height)) / 2.0;
+            self.x = x + width / 2.0;
+            self.y = y + height / 2.0;
+            self.radius = r.max(1.0);
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            let x_start = ((self.x - self.radius) as i32).max(0) as u32;
+            let y_start = ((self.y - self.radius) as i32).max(0) as u32;
+            let x_end = ((self.x + self.radius) as i32).min(buffer_width as i32) as u32;
+            let y_end = ((self.y + self.radius) as i32).min(buffer_height as i32) as u32;
+
+            for y in y_start..y_end {
+                for x in x_start..x_end {
+                    let dx = x as f64 - self.x;
+                    let dy = y as f64 - self.y;
+                    if dx * dx + dy * dy <= self.radius * self.radius {
+                        let offset = (y * (pitch as u32) + x * 4) as usize;
+                        if offset + 3 < buffer.len() {
+                            buffer[offset] = 0; // B
+                            buffer[offset + 1] = 120; // G
+                            buffer[offset + 2] = 0; // R
+                            buffer[offset + 3] = 255; // A
+                        }
+                    }
+                }
+            }
+        }
+    }
+});

--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -10,6 +10,12 @@ hotline::object!({
         focused: bool,
         highlight: Option<HighlightLens>,
         text_renderer: Option<TextRenderer>,
+        #[setter]
+        #[default((255, 255, 255, 255))]
+        text_color: (u8, u8, u8, u8),
+        #[setter]
+        #[default(0.0)]
+        scroll_offset: f64,
     }
 
     impl CodeEditor {
@@ -24,7 +30,16 @@ hotline::object!({
             }
 
             if self.text_renderer.is_none() {
-                self.text_renderer = Some(TextRenderer::new());
+                let mut tr = TextRenderer::new();
+                tr.set_color(self.text_color);
+                self.text_renderer = Some(tr);
+            }
+        }
+
+        pub fn update_text_color(&mut self, color: (u8, u8, u8, u8)) {
+            self.text_color = color;
+            if let Some(ref mut tr) = self.text_renderer {
+                tr.set_color(color);
             }
         }
 
@@ -71,6 +86,15 @@ hotline::object!({
             }
         }
 
+        pub fn scroll_by(&mut self, delta: f64) {
+            if let Some(ref mut rect) = self.rect {
+                let line_height = 14.0;
+                let total_height = self.text.lines().count() as f64 * line_height;
+                let max_offset = (total_height - rect.bounds().3).max(0.0);
+                self.scroll_offset = (self.scroll_offset + delta).max(0.0).min(max_offset);
+            }
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             if let Some(registry) = self.get_registry() {
                 ::hotline::set_library_registry(registry);
@@ -78,9 +102,10 @@ hotline::object!({
 
             if let Some(ref mut rect) = self.rect {
                 let (x, y, w, h) = rect.bounds();
+                let scroll_bar_width = 8.0;
                 let x_start = x.max(0.0) as u32;
                 let y_start = y.max(0.0) as u32;
-                let x_end = (x + w).min(buffer_width as f64) as u32;
+                let x_end = (x + w - scroll_bar_width).min(buffer_width as f64) as u32;
                 let y_end = (y + h).min(buffer_height as f64) as u32;
 
                 // Draw background
@@ -96,17 +121,42 @@ hotline::object!({
                     }
                 }
 
-                let mut cursor_y = y + 10.0;
                 let line_height = 14.0;
 
+                let mut cursor_y = y + 10.0 - self.scroll_offset;
+
                 if let Some(ref mut tr) = self.text_renderer {
-                    tr.set_color((255, 255, 255, 255));
+                    tr.set_color(self.text_color);
                     for line in self.text.split('\n') {
-                        tr.set_text(line.to_string());
-                        tr.set_x(x + 10.0);
-                        tr.set_y(cursor_y);
-                        tr.render(buffer, buffer_width, buffer_height, pitch);
+                        if cursor_y + line_height >= y && cursor_y <= y + h {
+                            tr.set_text(line.to_string());
+                            tr.set_x(x + 10.0);
+                            tr.set_y(cursor_y);
+                            tr.render(buffer, buffer_width, buffer_height, pitch);
+                        }
                         cursor_y += line_height;
+                    }
+                }
+
+                let total_height = self.text.lines().count() as f64 * line_height;
+                if total_height > h {
+                    let bar_height = (h / total_height) * h;
+                    let bar_y = y + (self.scroll_offset / total_height) * h;
+                    let bar_x_start = (x + w - scroll_bar_width).max(0.0) as u32;
+                    let bar_x_end = (x + w).min(buffer_width as f64) as u32;
+                    let bar_y_start = bar_y.max(0.0) as u32;
+                    let bar_y_end = (bar_y + bar_height).min(buffer_height as f64).min(y + h) as u32;
+
+                    for py in bar_y_start..bar_y_end {
+                        for px in bar_x_start..bar_x_end {
+                            let offset = (py * (pitch as u32) + px * 4) as usize;
+                            if offset + 3 < buffer.len() {
+                                buffer[offset] = 80;
+                                buffer[offset + 1] = 80;
+                                buffer[offset + 2] = 80;
+                                buffer[offset + 3] = 255;
+                            }
+                        }
                     }
                 }
 

--- a/objects/ColorWheel/Cargo.toml
+++ b/objects/ColorWheel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ColorWheel"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/ColorWheel/src/lib.rs
+++ b/objects/ColorWheel/src/lib.rs
@@ -1,0 +1,96 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Clone, Default)]
+    pub struct ColorWheel {
+        rect: Option<Rect>,
+        #[setter]
+        #[default((255, 255, 255, 255))]
+        selected_color: (u8, u8, u8, u8),
+    }
+
+    impl ColorWheel {
+        pub fn set_rect(&mut self, rect: Rect) {
+            self.rect = Some(rect);
+        }
+
+        pub fn selected_color(&mut self) -> (u8, u8, u8, u8) {
+            self.selected_color
+        }
+
+        pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> Option<(u8, u8, u8, u8)> {
+            if let Some(ref mut r) = self.rect {
+                if r.contains_point(x, y) {
+                    let (rx, ry, w, h) = r.bounds();
+                    let cx = rx + w / 2.0;
+                    let cy = ry + h / 2.0;
+                    let radius = w.min(h) / 2.0;
+                    let dx = x - cx;
+                    let dy = y - cy;
+                    let dist = (dx * dx + dy * dy).sqrt();
+                    if dist <= radius {
+                        let h = (dy.atan2(dx) + std::f64::consts::PI) / (2.0 * std::f64::consts::PI);
+                        let s = dist / radius;
+                        let v = 1.0;
+                        let (r_col, g_col, b_col) = Self::hsv_to_rgb(h, s, v);
+                        self.selected_color = (b_col, g_col, r_col, 255);
+                        return Some(self.selected_color);
+                    }
+                }
+            }
+            None
+        }
+
+        fn hsv_to_rgb(h: f64, s: f64, v: f64) -> (u8, u8, u8) {
+            let i = (h * 6.0).floor();
+            let f = h * 6.0 - i;
+            let p = v * (1.0 - s);
+            let q = v * (1.0 - f * s);
+            let t = v * (1.0 - (1.0 - f) * s);
+            let (r, g, b) = match i as i32 % 6 {
+                0 => (v, t, p),
+                1 => (q, v, p),
+                2 => (p, v, t),
+                3 => (p, q, v),
+                4 => (t, p, v),
+                _ => (v, p, q),
+            };
+            ((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if let Some(ref mut rect) = self.rect {
+                let (x, y, w, h) = rect.bounds();
+                let cx = x + w / 2.0;
+                let cy = y + h / 2.0;
+                let radius = w.min(h) / 2.0;
+
+                let x_start = x.max(0.0) as u32;
+                let y_start = y.max(0.0) as u32;
+                let x_end = (x + w).min(buffer_width as f64) as u32;
+                let y_end = (y + h).min(buffer_height as f64) as u32;
+
+                for py in y_start..y_end {
+                    for px in x_start..x_end {
+                        let dx = px as f64 + 0.5 - cx;
+                        let dy = py as f64 + 0.5 - cy;
+                        let dist = (dx * dx + dy * dy).sqrt();
+                        if dist <= radius {
+                            let h_val = (dy.atan2(dx) + std::f64::consts::PI) / (2.0 * std::f64::consts::PI);
+                            let s_val = dist / radius;
+                            let v_val = 1.0;
+                            let (r_col, g_col, b_col) = Self::hsv_to_rgb(h_val, s_val, v_val);
+                            let offset = (py * (pitch as u32) + px * 4) as usize;
+                            if offset + 3 < buffer.len() {
+                                buffer[offset] = b_col;
+                                buffer[offset + 1] = g_col;
+                                buffer[offset + 2] = r_col;
+                                buffer[offset + 3] = 255;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+});

--- a/objects/ContextMenu/Cargo.toml
+++ b/objects/ContextMenu/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ContextMenu"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/ContextMenu/src/lib.rs
+++ b/objects/ContextMenu/src/lib.rs
@@ -1,0 +1,71 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Default)]
+    pub struct ContextMenu {
+        items: Vec<String>,
+        renderers: Vec<TextRenderer>,
+        x: f64,
+        y: f64,
+        visible: bool,
+    }
+
+    impl ContextMenu {
+        fn initialize(&mut self) {
+            if self.items.is_empty() {
+                self.items = vec!["Rect".to_string(), "RegularPolygon".to_string(), "Circle".to_string()];
+            }
+
+            if self.renderers.is_empty() {
+                if let Some(registry) = self.get_registry() {
+                    ::hotline::set_library_registry(registry);
+                }
+                for item in &self.items {
+                    self.renderers.push(TextRenderer::new().with_text(item.clone()).with_color((255, 255, 255, 255)));
+                }
+            }
+        }
+
+        pub fn open(&mut self, x: f64, y: f64) {
+            self.initialize();
+            self.x = x;
+            self.y = y;
+            self.visible = true;
+        }
+
+        pub fn close(&mut self) {
+            self.visible = false;
+        }
+
+        pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> Option<String> {
+            if !self.visible {
+                return None;
+            }
+            let item_height = 16.0;
+            let mut cursor_y = self.y;
+            let mut result = None;
+            for item in &self.items {
+                if x >= self.x && x <= self.x + 100.0 && y >= cursor_y && y <= cursor_y + item_height {
+                    result = Some(item.clone());
+                    break;
+                }
+                cursor_y += item_height;
+            }
+            self.visible = false;
+            result
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if !self.visible {
+                return;
+            }
+            self.initialize();
+            let item_height = 16.0;
+            for (i, renderer) in self.renderers.iter_mut().enumerate() {
+                renderer.set_x(self.x);
+                renderer.set_y(self.y + i as f64 * item_height);
+                renderer.render(buffer, buffer_width, buffer_height, pitch);
+            }
+        }
+    }
+});

--- a/objects/HighlightLens/src/lib.rs
+++ b/objects/HighlightLens/src/lib.rs
@@ -6,13 +6,50 @@ hotline::object!({
         #[setter]
         #[default((0, 255, 0, 255))]
         highlight_color: (u8, u8, u8, u8), // BGRA
+        #[setter]
+        #[default(false)]
+        show_handles: bool,
     }
 
     impl HighlightLens {
+        fn draw_line(
+            buffer: &mut [u8],
+            bw: i64,
+            bh: i64,
+            pitch: i64,
+            b: u8,
+            g: u8,
+            r: u8,
+            a: u8,
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+        ) {
+            let dx = x1 - x0;
+            let dy = y1 - y0;
+            let steps = dx.abs().max(dy.abs()) as i64;
+            if steps == 0 {
+                return;
+            }
+            for i in 0..=steps {
+                let t = i as f64 / steps as f64;
+                let x = x0 + dx * t;
+                let y = y0 + dy * t;
+                if x >= 0.0 && x < bw as f64 && y >= 0.0 && y < bh as f64 {
+                    let offset = (y as i64 * pitch + x as i64 * 4) as usize;
+                    if offset + 3 < buffer.len() {
+                        buffer[offset] = b;
+                        buffer[offset + 1] = g;
+                        buffer[offset + 2] = r;
+                        buffer[offset + 3] = a;
+                    }
+                }
+            }
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             if let Some(ref mut target) = self.target {
-                // Only draw highlight border (rect is already rendered by WindowManager)
-                // Now just call bounds() directly!
                 let (x, y, width, height) = target.bounds();
 
                 let x_start = (x as i32).max(0) as u32;
@@ -20,41 +57,45 @@ hotline::object!({
                 let x_end = ((x + width) as i32).min(buffer_width as i32) as u32;
                 let y_end = ((y + height) as i32).min(buffer_height as i32) as u32;
 
+                let corners = target.corners();
                 let (b, g, r, a) = self.highlight_color;
 
-                // Top and bottom borders
-                for x in x_start..x_end {
-                    let top_offset = (y_start * (pitch as u32) + x * 4) as usize;
-                    let bottom_offset = ((y_end - 1) * (pitch as u32) + x * 4) as usize;
-                    if top_offset + 3 < buffer.len() {
-                        buffer[top_offset] = b;
-                        buffer[top_offset + 1] = g;
-                        buffer[top_offset + 2] = r;
-                        buffer[top_offset + 3] = a;
-                    }
-                    if bottom_offset + 3 < buffer.len() {
-                        buffer[bottom_offset] = b;
-                        buffer[bottom_offset + 1] = g;
-                        buffer[bottom_offset + 2] = r;
-                        buffer[bottom_offset + 3] = a;
-                    }
+                for i in 0..4 {
+                    let (x0, y0) = corners[i];
+                    let (x1, y1) = corners[(i + 1) % 4];
+                    Self::draw_line(buffer, buffer_width, buffer_height, pitch, b, g, r, a, x0, y0, x1, y1);
                 }
 
-                // Left and right borders
-                for y in y_start..y_end {
-                    let left_offset = (y * (pitch as u32) + x_start * 4) as usize;
-                    let right_offset = (y * (pitch as u32) + (x_end - 1) * 4) as usize;
-                    if left_offset + 3 < buffer.len() {
-                        buffer[left_offset] = b;
-                        buffer[left_offset + 1] = g;
-                        buffer[left_offset + 2] = r;
-                        buffer[left_offset + 3] = a;
-                    }
-                    if right_offset + 3 < buffer.len() {
-                        buffer[right_offset] = b;
-                        buffer[right_offset + 1] = g;
-                        buffer[right_offset + 2] = r;
-                        buffer[right_offset + 3] = a;
+                if self.show_handles {
+                    let handle = 6u32;
+                    let half = handle / 2;
+                    let mid_x = (x_start + x_end) / 2;
+                    let mid_y = (y_start + y_end) / 2;
+                    let mut positions = vec![
+                        (x_start, y_start),
+                        (x_end.saturating_sub(handle), y_start),
+                        (x_start, y_end.saturating_sub(handle)),
+                        (x_end.saturating_sub(handle), y_end.saturating_sub(handle)),
+                        (x_start, mid_y.saturating_sub(half)),
+                        (x_end.saturating_sub(handle), mid_y.saturating_sub(half)),
+                        (mid_x.saturating_sub(half), y_start),
+                        (mid_x.saturating_sub(half), y_end.saturating_sub(handle)),
+                    ];
+
+                    for (hx, hy) in positions.drain(..) {
+                        for py in hy..hy + handle {
+                            for px in hx..hx + handle {
+                                if px < buffer_width as u32 && py < buffer_height as u32 {
+                                    let off = (py * (pitch as u32) + px * 4) as usize;
+                                    if off + 3 < buffer.len() {
+                                        buffer[off] = b;
+                                        buffer[off + 1] = g;
+                                        buffer[off + 2] = r;
+                                        buffer[off + 3] = a;
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/objects/Rect/src/lib.rs
+++ b/objects/Rect/src/lib.rs
@@ -5,6 +5,8 @@ hotline::object!({
         y: f64,
         width: f64,
         height: f64,
+        #[default(0.0)]
+        rotation: f64, // radians
     }
 
     impl Rect {
@@ -13,10 +15,17 @@ hotline::object!({
             self.y = y;
             self.width = width;
             self.height = height;
+            self.rotation = 0.0;
         }
 
         pub fn contains_point(&mut self, point_x: f64, point_y: f64) -> bool {
-            point_x >= self.x && point_x <= self.x + self.width && point_y >= self.y && point_y <= self.y + self.height
+            let (cx, cy) = self.center();
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+            let dx = point_x - cx;
+            let dy = point_y - cy;
+            let rx = dx * cos_r + dy * sin_r;
+            let ry = -dx * sin_r + dy * cos_r;
+            rx.abs() <= self.width / 2.0 && ry.abs() <= self.height / 2.0
         }
 
         pub fn position(&mut self) -> (f64, f64) {
@@ -24,7 +33,14 @@ hotline::object!({
         }
 
         pub fn bounds(&mut self) -> (f64, f64, f64, f64) {
-            (self.x, self.y, self.width, self.height)
+            let corners = self.corners();
+            let xs = [corners[0].0, corners[1].0, corners[2].0, corners[3].0];
+            let ys = [corners[0].1, corners[1].1, corners[2].1, corners[3].1];
+            let min_x = xs.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max_x = xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            let min_y = ys.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max_y = ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            (min_x, min_y, max_x - min_x, max_y - min_y)
         }
 
         pub fn move_by(&mut self, dx: f64, dy: f64) {
@@ -32,22 +48,62 @@ hotline::object!({
             self.y += dy;
         }
 
-        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
-            // Draw rectangle by setting pixels
-            let x_start = (self.x as i32).max(0) as u32;
-            let y_start = (self.y as i32).max(0) as u32;
-            let x_end = ((self.x + self.width) as i32).min(buffer_width as i32) as u32;
-            let y_end = ((self.y + self.height) as i32).min(buffer_height as i32) as u32;
+        pub fn set_rotation(&mut self, angle: f64) {
+            self.rotation = angle;
+        }
 
-            // Draw filled rectangle
+        pub fn rotation(&mut self) -> f64 {
+            self.rotation
+        }
+
+        pub fn center(&mut self) -> (f64, f64) {
+            (self.x + self.width / 2.0, self.y + self.height / 2.0)
+        }
+
+        pub fn corners(&mut self) -> [(f64, f64); 4] {
+            let (cx, cy) = self.center();
+            let hw = self.width / 2.0;
+            let hh = self.height / 2.0;
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+            let mut rot = |dx: f64, dy: f64| -> (f64, f64) {
+                let rx = dx * cos_r - dy * sin_r;
+                let ry = dx * sin_r + dy * cos_r;
+                (cx + rx, cy + ry)
+            };
+            [rot(-hw, -hh), rot(hw, -hh), rot(hw, hh), rot(-hw, hh)]
+        }
+
+        pub fn resize(&mut self, x: f64, y: f64, width: f64, height: f64) {
+            self.x = x;
+            self.y = y;
+            self.width = width;
+            self.height = height;
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            let (bx, by, bw, bh) = self.bounds();
+            let x_start = (bx as i32).max(0) as u32;
+            let y_start = (by as i32).max(0) as u32;
+            let x_end = ((bx + bw) as i32).min(buffer_width as i32) as u32;
+            let y_end = ((by + bh) as i32).min(buffer_height as i32) as u32;
+
+            let (cx, cy) = self.center();
+            let (sin_r, cos_r) = self.rotation.sin_cos();
+
             for y in y_start..y_end {
                 for x in x_start..x_end {
-                    let offset = (y * (pitch as u32) + x * 4) as usize;
-                    if offset + 3 < buffer.len() {
-                        buffer[offset] = 120; // B
-                        buffer[offset + 1] = 0; // G
-                        buffer[offset + 2] = 0; // R
-                        buffer[offset + 3] = 255; // A
+                    let dx = x as f64 - cx;
+                    let dy = y as f64 - cy;
+                    let rx = dx * cos_r + dy * sin_r;
+                    let ry = -dx * sin_r + dy * cos_r;
+                    if rx.abs() <= self.width / 2.0 && ry.abs() <= self.height / 2.0 {
+                        let offset = (y * (pitch as u32) + x * 4) as usize;
+                        if offset + 3 < buffer.len() {
+                            buffer[offset] = 120; // B
+                            buffer[offset + 1] = 0; // G
+                            buffer[offset + 2] = 0; // R
+                            buffer[offset + 3] = 255; // A
+                        }
                     }
                 }
             }

--- a/objects/RegularPolygon/Cargo.toml
+++ b/objects/RegularPolygon/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "RegularPolygon"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/RegularPolygon/src/lib.rs
+++ b/objects/RegularPolygon/src/lib.rs
@@ -1,0 +1,133 @@
+hotline::object!({
+    #[derive(Default, Clone)]
+    pub struct RegularPolygon {
+        #[setter]
+        #[default(0.0)]
+        x: f64,
+        #[setter]
+        #[default(0.0)]
+        y: f64,
+        #[setter]
+        #[default(10.0)]
+        radius: f64,
+        #[setter]
+        #[default(3)]
+        sides: i64,
+        #[setter]
+        #[default(0.0)]
+        rotation: f64,
+        #[setter]
+        #[default((255,0,0,255))]
+        color: (u8, u8, u8, u8),
+    }
+
+    impl RegularPolygon {
+        pub fn initialize(&mut self, x: f64, y: f64, radius: f64, sides: i64) {
+            self.x = x;
+            self.y = y;
+            self.radius = radius;
+            self.sides = sides.max(3);
+        }
+
+        pub fn contains_point(&mut self, px: f64, py: f64) -> bool {
+            let verts = self.vertices();
+            self.point_in_polygon(px, py, &verts)
+        }
+
+        pub fn position(&mut self) -> (f64, f64) {
+            (self.x, self.y)
+        }
+
+        pub fn bounds(&mut self) -> (f64, f64, f64, f64) {
+            let verts = self.vertices();
+            let min_x = verts.iter().map(|(x, _)| *x).fold(f64::INFINITY, f64::min);
+            let max_x = verts.iter().map(|(x, _)| *x).fold(f64::NEG_INFINITY, f64::max);
+            let min_y = verts.iter().map(|(_, y)| *y).fold(f64::INFINITY, f64::min);
+            let max_y = verts.iter().map(|(_, y)| *y).fold(f64::NEG_INFINITY, f64::max);
+            (min_x, min_y, max_x - min_x, max_y - min_y)
+        }
+
+        pub fn corners(&mut self) -> [(f64, f64); 4] {
+            let (x, y, w, h) = self.bounds();
+            [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
+        }
+
+        pub fn move_by(&mut self, dx: f64, dy: f64) {
+            self.x += dx;
+            self.y += dy;
+        }
+
+        pub fn resize(&mut self, x: f64, y: f64, width: f64, height: f64) {
+            let r = (width.max(height)) / 2.0;
+            self.x = x + width / 2.0;
+            self.y = y + height / 2.0;
+            self.radius = r.max(1.0);
+        }
+
+        pub fn set_rotation(&mut self, angle: f64) {
+            self.rotation = angle;
+        }
+
+        pub fn rotation(&mut self) -> f64 {
+            self.rotation
+        }
+
+        fn vertices(&self) -> Vec<(f64, f64)> {
+            let mut verts = Vec::new();
+            let sides = self.sides.max(3) as usize;
+            for i in 0..sides {
+                let angle = 2.0 * std::f64::consts::PI * (i as f64) / (sides as f64) + self.rotation;
+                let vx = self.x + self.radius * angle.cos();
+                let vy = self.y + self.radius * angle.sin();
+                verts.push((vx, vy));
+            }
+            verts
+        }
+
+        fn point_in_polygon(&self, px: f64, py: f64, verts: &[(f64, f64)]) -> bool {
+            let mut inside = false;
+            let mut j = verts.len() - 1;
+            for i in 0..verts.len() {
+                let (xi, yi) = verts[i];
+                let (xj, yj) = verts[j];
+                let intersect = ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi);
+                if intersect {
+                    inside = !inside;
+                }
+                j = i;
+            }
+            inside
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if self.radius <= 0.0 {
+                return;
+            }
+            let verts = self.vertices();
+            let min_x = verts.iter().map(|(x, _)| *x).fold(std::f64::INFINITY, f64::min).floor().max(0.0) as i32;
+            let max_x =
+                verts.iter().map(|(x, _)| *x).fold(std::f64::NEG_INFINITY, f64::max).ceil().min(buffer_width as f64)
+                    as i32;
+            let min_y = verts.iter().map(|(_, y)| *y).fold(std::f64::INFINITY, f64::min).floor().max(0.0) as i32;
+            let max_y =
+                verts.iter().map(|(_, y)| *y).fold(std::f64::NEG_INFINITY, f64::max).ceil().min(buffer_height as f64)
+                    as i32;
+
+            let (b, g, r, a) = self.color;
+
+            for y in min_y..max_y {
+                for x in min_x..max_x {
+                    if self.point_in_polygon(x as f64 + 0.5, y as f64 + 0.5, &verts) {
+                        let offset = (y as u32 * pitch as u32 + x as u32 * 4) as usize;
+                        if offset + 3 < buffer.len() {
+                            buffer[offset] = b;
+                            buffer[offset + 1] = g;
+                            buffer[offset + 2] = r;
+                            buffer[offset + 3] = a;
+                        }
+                    }
+                }
+            }
+        }
+    }
+});

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -1,16 +1,45 @@
 use hotline::HotlineObject;
 
 hotline::object!({
+    #[derive(Clone, Copy, PartialEq, Default)]
+    enum ResizeDir {
+        #[default]
+        None,
+        Left,
+        Right,
+        Top,
+        Bottom,
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight,
+    }
+
+    #[derive(Clone)]
+    enum SelectedShape {
+        Rect(Rect),
+        Polygon(RegularPolygon),
+        Circle(Circle),
+    }
+
     #[derive(Default)]
     pub struct WindowManager {
         rects: Vec<Rect>,
+        polygons: Vec<RegularPolygon>,
+        circles: Vec<Circle>,
         selected: Option<Rect>,
+        selected_shape: Option<SelectedShape>,
         highlight_lens: Option<HighlightLens>, // HighlightLens for selected rect
         text_renderer: Option<TextRenderer>,   // TextRenderer for displaying text
+        context_menu: Option<ContextMenu>,
         dragging: bool,
         drag_offset_x: f64,
         drag_offset_y: f64,
         drag_start: Option<(f64, f64)>,
+        resizing: bool,
+        resize_dir: ResizeDir,
+        resize_start: Option<(f64, f64)>,
+        resize_orig: Option<(f64, f64, f64, f64)>,
     }
 
     impl WindowManager {
@@ -38,8 +67,13 @@ hotline::object!({
 
         pub fn clear_selection(&mut self) {
             self.selected = None;
+            self.selected_shape = None;
             self.highlight_lens = None;
             self.dragging = false;
+            self.resizing = false;
+            self.resize_dir = ResizeDir::None;
+            self.resize_start = None;
+            self.resize_orig = None;
         }
 
         pub fn set_drag_offset(&mut self, x: f64, y: f64) {
@@ -77,36 +111,192 @@ hotline::object!({
         }
 
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) {
+            if let Some(ref mut menu) = self.context_menu {
+                if let Some(selection) = menu.handle_mouse_down(x, y) {
+                    match selection.as_str() {
+                        "Rect" => {
+                            let mut r = Rect::new();
+                            r.initialize(x, y, 100.0, 100.0);
+                            self.rects.push(r);
+                        }
+                        "RegularPolygon" => {
+                            let mut p = RegularPolygon::new();
+                            p.initialize(x, y, 40.0, 5);
+                            self.polygons.push(p);
+                        }
+                        "Circle" => {
+                            let mut c = Circle::new();
+                            c.initialize(x, y, 40.0);
+                            self.circles.push(c);
+                        }
+                        _ => {}
+                    }
+                }
+                self.context_menu = None;
+                return;
+            }
+
             // First check for hits
-            let mut hit_index = None;
+            let mut hit_shape: Option<SelectedShape> = None;
             let mut hit_position = (0.0, 0.0);
+            let mut resize_dir = ResizeDir::None;
+            let mut resize_bounds = None;
 
-            for (i, rect_handle) in self.rects.iter_mut().enumerate().rev() {
-                // Check if this rect contains the point
-                if rect_handle.contains_point(x, y) {
-                    hit_index = Some(i);
+            // Circles
+            for circle in self.circles.iter_mut().enumerate().rev() {
+                let (i, circle_handle) = circle;
+                let (rx, ry, rw, rh) = circle_handle.bounds();
+                let margin = 5.0;
+                let inside = circle_handle.contains_point(x, y);
+                let near_left = (x - rx).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                let near_right = (x - (rx + rw)).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                let near_top = (y - ry).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+                let near_bottom = (y - (ry + rh)).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
 
-                    // Get rect position for offset calculation
-                    hit_position = rect_handle.position();
+                if near_left && near_top {
+                    resize_dir = ResizeDir::TopLeft;
+                } else if near_right && near_top {
+                    resize_dir = ResizeDir::TopRight;
+                } else if near_left && near_bottom {
+                    resize_dir = ResizeDir::BottomLeft;
+                } else if near_right && near_bottom {
+                    resize_dir = ResizeDir::BottomRight;
+                } else if near_left {
+                    resize_dir = ResizeDir::Left;
+                } else if near_right {
+                    resize_dir = ResizeDir::Right;
+                } else if near_top {
+                    resize_dir = ResizeDir::Top;
+                } else if near_bottom {
+                    resize_dir = ResizeDir::Bottom;
+                }
+
+                if resize_dir != ResizeDir::None || inside {
+                    hit_shape = Some(SelectedShape::Circle(circle_handle.clone()));
+                    hit_position = circle_handle.position();
+                    resize_bounds = Some(circle_handle.bounds());
                     break;
+                }
+            }
+
+            // Polygons
+            if hit_shape.is_none() {
+                for poly in self.polygons.iter_mut().enumerate().rev() {
+                    let (i, poly_handle) = poly;
+                    let (rx, ry, rw, rh) = poly_handle.bounds();
+                    let margin = 5.0;
+                    let inside = poly_handle.contains_point(x, y);
+                    let near_left = (x - rx).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                    let near_right = (x - (rx + rw)).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                    let near_top = (y - ry).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+                    let near_bottom = (y - (ry + rh)).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+
+                    if near_left && near_top {
+                        resize_dir = ResizeDir::TopLeft;
+                    } else if near_right && near_top {
+                        resize_dir = ResizeDir::TopRight;
+                    } else if near_left && near_bottom {
+                        resize_dir = ResizeDir::BottomLeft;
+                    } else if near_right && near_bottom {
+                        resize_dir = ResizeDir::BottomRight;
+                    } else if near_left {
+                        resize_dir = ResizeDir::Left;
+                    } else if near_right {
+                        resize_dir = ResizeDir::Right;
+                    } else if near_top {
+                        resize_dir = ResizeDir::Top;
+                    } else if near_bottom {
+                        resize_dir = ResizeDir::Bottom;
+                    }
+
+                    if resize_dir != ResizeDir::None || inside {
+                        hit_shape = Some(SelectedShape::Polygon(poly_handle.clone()));
+                        hit_position = poly_handle.position();
+                        resize_bounds = Some(poly_handle.bounds());
+                        break;
+                    }
+                }
+            }
+
+            // Rectangles
+            if hit_shape.is_none() {
+                for rect_handle in self.rects.iter_mut().enumerate().rev() {
+                    let (i, rect_handle) = rect_handle;
+                    let (rx, ry, rw, rh) = rect_handle.bounds();
+                    let margin = 5.0;
+                    let inside = rect_handle.contains_point(x, y);
+                    let near_left = (x - rx).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                    let near_right = (x - (rx + rw)).abs() <= margin && y >= ry - margin && y <= ry + rh + margin;
+                    let near_top = (y - ry).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+                    let near_bottom = (y - (ry + rh)).abs() <= margin && x >= rx - margin && x <= rx + rw + margin;
+
+                    if near_left && near_top {
+                        resize_dir = ResizeDir::TopLeft;
+                    } else if near_right && near_top {
+                        resize_dir = ResizeDir::TopRight;
+                    } else if near_left && near_bottom {
+                        resize_dir = ResizeDir::BottomLeft;
+                    } else if near_right && near_bottom {
+                        resize_dir = ResizeDir::BottomRight;
+                    } else if near_left {
+                        resize_dir = ResizeDir::Left;
+                    } else if near_right {
+                        resize_dir = ResizeDir::Right;
+                    } else if near_top {
+                        resize_dir = ResizeDir::Top;
+                    } else if near_bottom {
+                        resize_dir = ResizeDir::Bottom;
+                    }
+
+                    if resize_dir != ResizeDir::None || inside {
+                        hit_shape = Some(SelectedShape::Rect(rect_handle.clone()));
+                        hit_position = rect_handle.position();
+                        resize_bounds = Some(rect_handle.bounds());
+                        break;
+                    }
                 }
             }
 
             // Clear previous selection
             self.clear_selection();
 
-            if let Some(index) = hit_index {
-                // Found a hit - select it
-                let rect_handle = &self.rects[index];
-
-                // Calculate drag offset from click position to rect position
-                self.drag_offset_x = hit_position.0 - x;
-                self.drag_offset_y = hit_position.1 - y;
-                self.selected = Some(rect_handle.clone());
-                self.dragging = true;
+            if let Some(shape) = hit_shape {
+                let mut rect_clone = Rect::new();
+                match shape.clone() {
+                    SelectedShape::Rect(handle) => {
+                        rect_clone = handle.clone();
+                        self.selected_shape = Some(SelectedShape::Rect(handle));
+                    }
+                    SelectedShape::Polygon(handle) => {
+                        let (bx, by, bw, bh) = handle.bounds();
+                        rect_clone.initialize(bx, by, bw, bh);
+                        self.selected_shape = Some(SelectedShape::Polygon(handle));
+                    }
+                    SelectedShape::Circle(handle) => {
+                        let (bx, by, bw, bh) = handle.bounds();
+                        rect_clone.initialize(bx, by, bw, bh);
+                        self.selected_shape = Some(SelectedShape::Circle(handle));
+                    }
+                }
+                self.selected = Some(rect_clone.clone());
 
                 // Create HighlightLens for selected rect
-                self.highlight_lens = Some(HighlightLens::new().with_target(rect_handle));
+                self.highlight_lens = Some(HighlightLens::new().with_target(&rect_clone).with_show_handles(true));
+
+                if resize_dir != ResizeDir::None {
+                    self.resizing = true;
+                    self.resize_dir = resize_dir;
+                    self.resize_start = Some((x, y));
+                    self.resize_orig = resize_bounds;
+                    if let Some(ref mut lens) = self.highlight_lens {
+                        lens.set_highlight_color((255, 255, 0, 255));
+                    }
+                } else {
+                    // Calculate drag offset from click position to rect position
+                    self.drag_offset_x = hit_position.0 - x;
+                    self.drag_offset_y = hit_position.1 - y;
+                    self.dragging = true;
+                }
             } else {
                 // No hit - start rect creation
                 self.drag_start = Some((x, y));
@@ -114,7 +304,17 @@ hotline::object!({
         }
 
         pub fn handle_mouse_up(&mut self, x: f64, y: f64) {
-            if self.dragging {
+            if self.context_menu.is_some() {
+                return;
+            } else if self.resizing {
+                self.resizing = false;
+                self.resize_dir = ResizeDir::None;
+                self.resize_start = None;
+                self.resize_orig = None;
+                if let Some(ref mut lens) = self.highlight_lens {
+                    lens.set_highlight_color((0, 255, 0, 255));
+                }
+            } else if self.dragging {
                 self.stop_dragging();
             } else if let Some((start_x, start_y)) = self.drag_start {
                 // Create a new rect directly
@@ -133,29 +333,151 @@ hotline::object!({
         }
 
         pub fn handle_mouse_motion(&mut self, x: f64, y: f64) {
+            if self.context_menu.is_some() {
+                return;
+            }
             if self.dragging {
-                if let Some(ref mut selected_handle) = self.selected {
-                    // Move the selected rect to follow the mouse
+                if let Some(ref mut shape) = self.selected_shape {
                     let new_x = x + self.drag_offset_x;
                     let new_y = y + self.drag_offset_y;
 
-                    // Get current position
-                    let (current_x, current_y) = selected_handle.position();
+                    match shape {
+                        SelectedShape::Rect(ref mut handle) => {
+                            let (cx, cy) = handle.position();
+                            let dx = new_x - cx;
+                            let dy = new_y - cy;
+                            handle.move_by(dx, dy);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.move_by(dx, dy);
+                            }
+                        }
+                        SelectedShape::Polygon(ref mut handle) => {
+                            let (cx, cy) = handle.position();
+                            let dx = new_x - cx;
+                            let dy = new_y - cy;
+                            handle.move_by(dx, dy);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.move_by(dx, dy);
+                            }
+                        }
+                        SelectedShape::Circle(ref mut handle) => {
+                            let (cx, cy) = handle.position();
+                            let dx = new_x - cx;
+                            let dy = new_y - cy;
+                            handle.move_by(dx, dy);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.move_by(dx, dy);
+                            }
+                        }
+                    }
+                }
+            } else if self.resizing {
+                if let (Some(ref mut shape), Some((start_x, start_y)), Some((orig_x, orig_y, orig_w, orig_h))) =
+                    (self.selected_shape.as_mut(), self.resize_start, self.resize_orig)
+                {
+                    let dx = x - start_x;
+                    let dy = y - start_y;
+                    let mut new_x = orig_x;
+                    let mut new_y = orig_y;
+                    let mut new_w = orig_w;
+                    let mut new_h = orig_h;
 
-                    // Calculate delta movement
-                    let dx = new_x - current_x;
-                    let dy = new_y - current_y;
+                    match self.resize_dir {
+                        ResizeDir::Left => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                        }
+                        ResizeDir::Right => {
+                            new_w = orig_w + dx;
+                        }
+                        ResizeDir::Top => {
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::Bottom => {
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::TopLeft => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::TopRight => {
+                            new_w = orig_w + dx;
+                            new_y = orig_y + dy;
+                            new_h = orig_h - dy;
+                        }
+                        ResizeDir::BottomLeft => {
+                            new_x = orig_x + dx;
+                            new_w = orig_w - dx;
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::BottomRight => {
+                            new_w = orig_w + dx;
+                            new_h = orig_h + dy;
+                        }
+                        ResizeDir::None => {}
+                    }
 
-                    // Move the rect
-                    selected_handle.move_by(dx, dy);
+                    if new_w < 1.0 {
+                        new_w = 1.0;
+                    }
+                    if new_h < 1.0 {
+                        new_h = 1.0;
+                    }
+
+                    match shape {
+                        SelectedShape::Rect(ref mut handle) => {
+                            handle.resize(new_x, new_y, new_w, new_h);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.resize(new_x, new_y, new_w, new_h);
+                            }
+                        }
+                        SelectedShape::Polygon(ref mut handle) => {
+                            handle.resize(new_x, new_y, new_w, new_h);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.resize(new_x, new_y, new_w, new_h);
+                            }
+                        }
+                        SelectedShape::Circle(ref mut handle) => {
+                            handle.resize(new_x, new_y, new_w, new_h);
+                            if let Some(ref mut rect) = self.selected {
+                                rect.resize(new_x, new_y, new_w, new_h);
+                            }
+                        }
+                    }
                 }
             }
+        }
+
+        pub fn rotate_selected(&mut self, angle: f64) {
+            if let Some(ref mut selected_handle) = self.selected {
+                let new_rot = selected_handle.rotation() + angle;
+                selected_handle.set_rotation(new_rot);
+            }
+        }
+
+        pub fn handle_right_click(&mut self, x: f64, y: f64) {
+            let mut menu = self.context_menu.take().unwrap_or_else(ContextMenu::new);
+            menu.open(x, y);
+            self.context_menu = Some(menu);
         }
 
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             // Render all rects
             for rect_handle in &mut self.rects {
                 rect_handle.render(buffer, buffer_width, buffer_height, pitch);
+            }
+
+            // Render polygons
+            for poly in &mut self.polygons {
+                poly.render(buffer, buffer_width, buffer_height, pitch);
+            }
+
+            // Render circles
+            for circle in &mut self.circles {
+                circle.render(buffer, buffer_width, buffer_height, pitch);
             }
 
             // Render the highlight lens if we have one (this will render the selected rect with highlight)
@@ -166,6 +488,11 @@ hotline::object!({
             // Render text
             if let Some(ref mut text_renderer) = self.text_renderer {
                 text_renderer.render(buffer, buffer_width, buffer_height, pitch);
+            }
+
+            // Render context menu if visible
+            if let Some(ref mut menu) = self.context_menu {
+                menu.render(buffer, buffer_width, buffer_height, pitch);
             }
         }
 


### PR DESCRIPTION
## Summary
- merge master
- add Circle object to context menu
- support selecting, moving and resizing circles and polygons

## Testing
- `cargo run --bin runtime --release` *(fails: library 'libApplication' not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68433055cd508325a448d4779efca01e