### PR TITLE
Add autonomous movement to rectangles

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -24,6 +24,8 @@ hotline::object!({
         frame_times: std::collections::VecDeque<std::time::Instant>,
         last_fps_update: Option<std::time::Instant>,
         current_fps: f64,
+        mouse_x: f64,
+        mouse_y: f64,
     }
 
     impl Application {
@@ -162,6 +164,8 @@ hotline::object!({
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_down(x as f64, y as f64);
                             }
+                            self.mouse_x = x as f64;
+                            self.mouse_y = y as f64;
                             if let Some(ref mut editor) = self.code_editor {
                                 editor.handle_mouse_down(x as f64, y as f64);
                             }
@@ -177,16 +181,22 @@ hotline::object!({
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_right_click(x as f64, y as f64);
                             }
+                            self.mouse_x = x as f64;
+                            self.mouse_y = y as f64;
                         }
                         Event::MouseButtonUp { mouse_btn: MouseButton::Left, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_up(x as f64, y as f64);
                             }
+                            self.mouse_x = x as f64;
+                            self.mouse_y = y as f64;
                         }
                         Event::MouseMotion { x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_motion(x as f64, y as f64);
                             }
+                            self.mouse_x = x as f64;
+                            self.mouse_y = y as f64;
                         }
                         Event::MouseWheel { y, .. } => {
                             if let Some(ref mut editor) = self.code_editor {
@@ -235,6 +245,10 @@ hotline::object!({
                         }
                         _ => {}
                     }
+                }
+
+                if let Some(ref mut wm) = self.window_manager {
+                    wm.update_autonomy(self.mouse_x, self.mouse_y);
                 }
 
                 // Render

--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -21,6 +21,7 @@ hotline::object!({
         gpu_atlases: Vec<AtlasData>,
         gpu_commands: Vec<RenderCommand>,
         fps_counter: Option<TextRenderer>,
+        autonomy_checkbox: Option<Checkbox>,
         frame_times: std::collections::VecDeque<std::time::Instant>,
         last_fps_update: Option<std::time::Instant>,
         current_fps: f64,
@@ -75,6 +76,16 @@ hotline::object!({
                 let mut r_ref = rect.clone();
                 r_ref.initialize(50.0, 400.0, 120.0, 120.0);
                 wheel.set_rect(rect);
+            }
+
+            // Create autonomy checkbox
+            self.autonomy_checkbox = Some(Checkbox::new());
+            if let Some(ref mut cb) = self.autonomy_checkbox {
+                let rect = Rect::new();
+                let mut r_ref = rect.clone();
+                r_ref.initialize(20.0, 60.0, 20.0, 20.0);
+                cb.set_rect(rect);
+                cb.set_label("Autonomy".to_string());
             }
 
             // Create FPS counter
@@ -176,6 +187,9 @@ hotline::object!({
                                     }
                                 }
                             }
+                            if let Some(ref mut cb) = self.autonomy_checkbox {
+                                cb.handle_mouse_down(x as f64, y as f64);
+                            }
                         }
                         Event::MouseButtonDown { mouse_btn: MouseButton::Right, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
@@ -247,8 +261,10 @@ hotline::object!({
                     }
                 }
 
-                if let Some(ref mut wm) = self.window_manager {
-                    wm.update_autonomy(self.mouse_x, self.mouse_y);
+                if let (Some(wm), Some(cb)) = (&mut self.window_manager, &mut self.autonomy_checkbox) {
+                    if cb.checked() {
+                        wm.update_autonomy(self.mouse_x, self.mouse_y);
+                    }
                 }
 
                 // Render
@@ -306,6 +322,10 @@ hotline::object!({
                     wheel.render(buffer, 800, 600, pitch as i64);
                 }
 
+                if let Some(ref mut cb) = self.autonomy_checkbox {
+                    cb.render(buffer, 800, 600, pitch as i64);
+                }
+
                 // Render FPS counter
                 if let Some(ref mut fps) = self.fps_counter {
                     fps.render(buffer, 800, 600, pitch as i64);
@@ -347,6 +367,10 @@ hotline::object!({
                 }
                 if let Some(ref mut wheel) = self.color_wheel {
                     wheel.render(buffer, 800, 600, pitch as i64);
+                }
+
+                if let Some(ref mut cb) = self.autonomy_checkbox {
+                    cb.render(buffer, 800, 600, pitch as i64);
                 }
 
                 // Render FPS counter

--- a/objects/Checkbox/Cargo.toml
+++ b/objects/Checkbox/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Checkbox"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/Checkbox/src/lib.rs
+++ b/objects/Checkbox/src/lib.rs
@@ -1,0 +1,88 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Clone, Default)]
+    pub struct Checkbox {
+        rect: Option<Rect>,
+        label: Option<TextRenderer>,
+        #[setter]
+        #[default(false)]
+        checked: bool,
+    }
+
+    impl Checkbox {
+        pub fn set_rect(&mut self, rect: Rect) {
+            self.rect = Some(rect);
+        }
+
+        pub fn set_label(&mut self, text: String) {
+            if self.label.is_none() {
+                if let Some(registry) = self.get_registry() {
+                    ::hotline::set_library_registry(registry);
+                }
+                self.label = Some(TextRenderer::new());
+            }
+            if let Some(ref mut tr) = self.label {
+                tr.set_text(text);
+                if let Some(ref mut r) = self.rect {
+                    let (x, y, w, _) = r.bounds();
+                    tr.set_x(x + w + 5.0);
+                    tr.set_y(y);
+                }
+            }
+        }
+
+        pub fn checked(&mut self) -> bool {
+            self.checked
+        }
+
+        pub fn handle_mouse_down(&mut self, x: f64, y: f64) {
+            if let Some(ref mut r) = self.rect {
+                if r.contains_point(x, y) {
+                    self.checked = !self.checked;
+                }
+            }
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], bw: i64, bh: i64, pitch: i64) {
+            if let Some(ref mut r) = self.rect {
+                r.render(buffer, bw, bh, pitch);
+                if self.checked {
+                    let (x, y, w, h) = r.bounds();
+                    let x = x as i64;
+                    let y = y as i64;
+                    let w = w as i64;
+                    let h = h as i64;
+                    let min_dim = w.min(h);
+                    for i in 0..min_dim {
+                        let px1 = x + i;
+                        let py1 = y + i;
+                        let px2 = x + i;
+                        let py2 = y + h - 1 - i;
+                        if px1 >= 0 && px1 < bw && py1 >= 0 && py1 < bh {
+                            let off = (py1 * pitch + px1 * 4) as usize;
+                            if off + 3 < buffer.len() {
+                                buffer[off] = 255;
+                                buffer[off + 1] = 255;
+                                buffer[off + 2] = 255;
+                                buffer[off + 3] = 255;
+                            }
+                        }
+                        if px2 >= 0 && px2 < bw && py2 >= 0 && py2 < bh {
+                            let off = (py2 * pitch + px2 * 4) as usize;
+                            if off + 3 < buffer.len() {
+                                buffer[off] = 255;
+                                buffer[off + 1] = 255;
+                                buffer[off + 2] = 255;
+                                buffer[off + 3] = 255;
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(ref mut tr) = self.label {
+                tr.render(buffer, bw, bh, pitch);
+            }
+        }
+    }
+});

--- a/objects/RectMover/Cargo.toml
+++ b/objects/RectMover/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2024"
+name = "RectMover"
+version = "0.1.0"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = {path = "../../hotline"}
+# do not add additional dependencies here

--- a/objects/RectMover/src/lib.rs
+++ b/objects/RectMover/src/lib.rs
@@ -1,0 +1,27 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Clone, Default)]
+    pub struct RectMover {
+        target: Option<Rect>,
+    }
+
+    impl RectMover {
+        pub fn set_target(&mut self, rect: Rect) {
+            self.target = Some(rect);
+        }
+
+        pub fn update(&mut self, mouse_x: f64, mouse_y: f64) {
+            if let Some(ref mut rect) = self.target {
+                let (cx, cy) = rect.center();
+                let dx = mouse_x - cx;
+                let dy = mouse_y - cy;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist > 1.0 {
+                    let step = 0.5;
+                    rect.move_by(dx / dist * step, dy / dist * step);
+                }
+            }
+        }
+    }
+});

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -112,7 +112,7 @@ hotline::object!({
                         "Rect" => {
                             let mut r = Rect::new();
                             r.initialize(x, y, 100.0, 100.0);
-                            self.rects.push(r);
+                            self.add_rect(r);
                         }
                         "RegularPolygon" => {
                             let mut p = RegularPolygon::new();

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -1,5 +1,6 @@
 use hotline::HotlineObject;
 
+// New object that moves rects toward the mouse cursor
 hotline::object!({
     #[derive(Clone, Copy, PartialEq, Default)]
     enum ResizeDir {
@@ -18,6 +19,7 @@ hotline::object!({
     #[derive(Default)]
     pub struct WindowManager {
         rects: Vec<Rect>,
+        rect_movers: Vec<RectMover>,
         polygons: Vec<RegularPolygon>,
         selected: Option<Rect>,
         highlight_lens: Option<HighlightLens>, // HighlightLens for selected rect
@@ -53,6 +55,9 @@ hotline::object!({
         }
 
         pub fn add_rect(&mut self, rect: Rect) {
+            let mut mover = RectMover::new();
+            mover.set_target(rect.clone());
+            self.rect_movers.push(mover);
             self.rects.push(rect);
         }
 
@@ -318,6 +323,12 @@ hotline::object!({
             let mut menu = self.context_menu.take().unwrap_or_else(ContextMenu::new);
             menu.open(x, y);
             self.context_menu = Some(menu);
+        }
+
+        pub fn update_autonomy(&mut self, mouse_x: f64, mouse_y: f64) {
+            for mover in &mut self.rect_movers {
+                mover.update(mouse_x, mouse_y);
+            }
         }
 
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {


### PR DESCRIPTION
## Summary
- add `RectMover` object for simple movement toward the cursor
- connect `RectMover` instances to rectangles in `WindowManager`
- track the mouse position in `Application` and update movers each frame

## Testing
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_684413e916b883258469459634fc4e96