### PR TITLE
Update color wheel interaction

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -182,10 +182,20 @@ hotline::object!({
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_up(x as f64, y as f64);
                             }
+                            if let Some(ref mut wheel) = self.color_wheel {
+                                wheel.handle_mouse_up();
+                            }
                         }
                         Event::MouseMotion { x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_motion(x as f64, y as f64);
+                            }
+                            if let Some(ref mut wheel) = self.color_wheel {
+                                if let Some(color) = wheel.handle_mouse_move(x as f64, y as f64) {
+                                    if let Some(ref mut editor) = self.code_editor {
+                                        editor.update_text_color(color);
+                                    }
+                                }
                             }
                         }
                         Event::MouseWheel { y, .. } => {

--- a/objects/ColorWheel/src/lib.rs
+++ b/objects/ColorWheel/src/lib.rs
@@ -7,6 +7,8 @@ hotline::object!({
         #[setter]
         #[default((255, 255, 255, 255))]
         selected_color: (u8, u8, u8, u8),
+        #[default(false)]
+        dragging: bool,
     }
 
     impl ColorWheel {
@@ -19,6 +21,25 @@ hotline::object!({
         }
 
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> Option<(u8, u8, u8, u8)> {
+            if let Some(color) = self.update_color_at(x, y) {
+                self.dragging = true;
+                return Some(color);
+            }
+            None
+        }
+
+        pub fn handle_mouse_up(&mut self) {
+            self.dragging = false;
+        }
+
+        pub fn handle_mouse_move(&mut self, x: f64, y: f64) -> Option<(u8, u8, u8, u8)> {
+            if self.dragging {
+                return self.update_color_at(x, y);
+            }
+            None
+        }
+
+        fn update_color_at(&mut self, x: f64, y: f64) -> Option<(u8, u8, u8, u8)> {
             if let Some(ref mut r) = self.rect {
                 if r.contains_point(x, y) {
                     let (rx, ry, w, h) = r.bounds();


### PR DESCRIPTION
## Summary
- add drag state to `ColorWheel`
- track mouse release and movement in `Application` so color changes continuously

## Testing
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_684413ae8d548325937da0629d67f0ea