### PR TITLE
Add click inspector window

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -175,6 +175,8 @@ hotline::object!({
                         }
                         Event::MouseButtonDown { mouse_btn: MouseButton::Right, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
+                                let hits = wm.inspect_click(x as f64, y as f64);
+                                wm.open_inspector(x as f64, y as f64, hits);
                                 wm.handle_right_click(x as f64, y as f64);
                             }
                         }

--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -161,6 +161,10 @@ hotline::object!({
                         Event::MouseButtonDown { mouse_btn: MouseButton::Left, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_down(x as f64, y as f64);
+                                let hits = wm.inspect_click(x as f64, y as f64);
+                                if !hits.is_empty() {
+                                    wm.open_inspector(x as f64, y as f64, hits);
+                                }
                             }
                             if let Some(ref mut editor) = self.code_editor {
                                 editor.handle_mouse_down(x as f64, y as f64);

--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -163,7 +163,7 @@ hotline::object!({
                                 wm.handle_mouse_down(x as f64, y as f64);
                                 let hits = wm.inspect_click(x as f64, y as f64);
                                 if !hits.is_empty() {
-                                    wm.open_inspector(x as f64, y as f64, hits);
+                                    wm.open_inspector(hits);
                                 }
                             }
                             if let Some(ref mut editor) = self.code_editor {
@@ -180,7 +180,9 @@ hotline::object!({
                         Event::MouseButtonDown { mouse_btn: MouseButton::Right, x, y, .. } => {
                             if let Some(ref mut wm) = self.window_manager {
                                 let hits = wm.inspect_click(x as f64, y as f64);
-                                wm.open_inspector(x as f64, y as f64, hits);
+                                if !hits.is_empty() {
+                                    wm.open_inspector(hits);
+                                }
                                 wm.handle_right_click(x as f64, y as f64);
                             }
                         }

--- a/objects/ClickInspector/Cargo.toml
+++ b/objects/ClickInspector/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ClickInspector"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }
+# do not add additional dependencies here

--- a/objects/ClickInspector/src/lib.rs
+++ b/objects/ClickInspector/src/lib.rs
@@ -1,0 +1,55 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Default)]
+    pub struct ClickInspector {
+        items: Vec<String>,
+        renderers: Vec<TextRenderer>,
+        x: f64,
+        y: f64,
+        visible: bool,
+    }
+
+    impl ClickInspector {
+        fn ensure_renderers(&mut self) {
+            if let Some(registry) = self.get_registry() {
+                ::hotline::set_library_registry(registry);
+            }
+            if self.renderers.len() != self.items.len() {
+                self.renderers.clear();
+                for item in &self.items {
+                    self.renderers.push(TextRenderer::new().with_text(item.clone()).with_color((255, 255, 255, 255)));
+                }
+            } else {
+                for (renderer, item) in self.renderers.iter_mut().zip(&self.items) {
+                    renderer.set_text(item.clone());
+                }
+            }
+        }
+
+        pub fn open(&mut self, x: f64, y: f64, items: Vec<String>) {
+            self.items = items;
+            self.x = x;
+            self.y = y;
+            self.visible = true;
+            self.ensure_renderers();
+        }
+
+        pub fn close(&mut self) {
+            self.visible = false;
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            if !self.visible {
+                return;
+            }
+            self.ensure_renderers();
+            let item_height = 16.0;
+            for (i, renderer) in self.renderers.iter_mut().enumerate() {
+                renderer.set_x(self.x);
+                renderer.set_y(self.y + i as f64 * item_height);
+                renderer.render(buffer, buffer_width, buffer_height, pitch);
+            }
+        }
+    }
+});

--- a/objects/ClickInspector/src/lib.rs
+++ b/objects/ClickInspector/src/lib.rs
@@ -5,7 +5,9 @@ hotline::object!({
     pub struct ClickInspector {
         items: Vec<String>,
         renderers: Vec<TextRenderer>,
+        #[default(10.0)]
         x: f64,
+        #[default(10.0)]
         y: f64,
         visible: bool,
     }
@@ -27,10 +29,8 @@ hotline::object!({
             }
         }
 
-        pub fn open(&mut self, x: f64, y: f64, items: Vec<String>) {
+        pub fn open(&mut self, items: Vec<String>) {
             self.items = items;
-            self.x = x;
-            self.y = y;
             self.visible = true;
             self.ensure_renderers();
         }

--- a/objects/Rect/src/lib.rs
+++ b/objects/Rect/src/lib.rs
@@ -80,6 +80,17 @@ hotline::object!({
             self.height = height;
         }
 
+        pub fn info_lines(&mut self) -> Vec<String> {
+            vec![
+                "Rect".to_string(),
+                format!("  x: {:.1}", self.x),
+                format!("  y: {:.1}", self.y),
+                format!("  width: {:.1}", self.width),
+                format!("  height: {:.1}", self.height),
+                format!("  rotation: {:.2}", self.rotation),
+            ]
+        }
+
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
             let (bx, by, bw, bh) = self.bounds();
             let x_start = (bx as i32).max(0) as u32;

--- a/objects/RegularPolygon/src/lib.rs
+++ b/objects/RegularPolygon/src/lib.rs
@@ -41,6 +41,11 @@ hotline::object!({
             verts
         }
 
+        pub fn contains_point(&self, x: f64, y: f64) -> bool {
+            let verts = self.vertices();
+            self.point_in_polygon(x, y, &verts)
+        }
+
         fn point_in_polygon(&self, px: f64, py: f64, verts: &[(f64, f64)]) -> bool {
             let mut inside = false;
             let mut j = verts.len() - 1;

--- a/objects/RegularPolygon/src/lib.rs
+++ b/objects/RegularPolygon/src/lib.rs
@@ -46,6 +46,19 @@ hotline::object!({
             self.point_in_polygon(x, y, &verts)
         }
 
+        pub fn info_lines(&mut self) -> Vec<String> {
+            let (b, g, r, a) = self.color;
+            vec![
+                "RegularPolygon".to_string(),
+                format!("  x: {:.1}", self.x),
+                format!("  y: {:.1}", self.y),
+                format!("  radius: {:.1}", self.radius),
+                format!("  sides: {}", self.sides),
+                format!("  rotation: {:.2}", self.rotation),
+                format!("  color: ({},{},{},{})", b, g, r, a),
+            ]
+        }
+
         fn point_in_polygon(&self, px: f64, py: f64, verts: &[(f64, f64)]) -> bool {
             let mut inside = false;
             let mut j = verts.len() - 1;

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -64,20 +64,20 @@ hotline::object!({
             let mut hits = Vec::new();
             for rect in &mut self.rects {
                 if rect.contains_point(x, y) {
-                    hits.push("Rect".to_string());
+                    hits.extend(rect.info_lines());
                 }
             }
             for poly in &mut self.polygons {
                 if poly.contains_point(x, y) {
-                    hits.push("RegularPolygon".to_string());
+                    hits.extend(poly.info_lines());
                 }
             }
             hits
         }
 
-        pub fn open_inspector(&mut self, x: f64, y: f64, items: Vec<String>) {
+        pub fn open_inspector(&mut self, items: Vec<String>) {
             if let Some(ref mut inspector) = self.click_inspector {
-                inspector.open(x, y, items);
+                inspector.open(items);
             }
         }
 
@@ -132,8 +132,6 @@ hotline::object!({
         }
 
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) {
-            self.close_inspector();
-
             if let Some(ref mut menu) = self.context_menu {
                 if let Some(selection) = menu.handle_mouse_down(x, y) {
                     match selection.as_str() {
@@ -228,7 +226,6 @@ hotline::object!({
         }
 
         pub fn handle_mouse_up(&mut self, x: f64, y: f64) {
-            self.close_inspector();
             if self.context_menu.is_some() {
                 return;
             } else if self.resizing {


### PR DESCRIPTION
## Summary
- add `ClickInspector` object to display clicked objects
- show `ClickInspector` from `WindowManager` on right-click
- expose inspector from `Application`

## Testing
- `cargo run --bin runtime --release`


------
https://chatgpt.com/codex/tasks/task_e_6844138b16a0832585a2905a3be5f245