### PR TITLE
Add automatic Inspectable impls

### DIFF
--- a/hotline-macros/src/codegen/wrapper.rs
+++ b/hotline-macros/src/codegen/wrapper.rs
@@ -133,6 +133,18 @@ fn generate_typed_wrapper(
         })
         .collect();
 
+    let symbol = crate::utils::symbols::SymbolName::new(type_name, "fields", rustc_commit)
+        .with_return_type("Vec_tuple_String_Comma_String".to_string());
+    let symbol_name = symbol.build_method();
+    let fn_type = quote! { unsafe extern "Rust" fn(&mut dyn std::any::Any) -> Vec<(String, String)> };
+    let method_body = crate::codegen::ffi::quote_method_call_with_registry(
+        quote! { self.0 },
+        "fields",
+        &symbol_name,
+        fn_type,
+        quote! {},
+    );
+
     quote! {
         #[derive(Clone)]
         pub struct #type_ident(::hotline::ObjectHandle);
@@ -200,6 +212,12 @@ fn generate_typed_wrapper(
                 } else {
                     None
                 }
+            }
+        }
+
+        impl ::hotline::Inspectable for #type_ident {
+            fn fields(&mut self) -> Vec<(String, String)> {
+                #method_body
             }
         }
     }

--- a/hotline-macros/src/lib.rs
+++ b/hotline-macros/src/lib.rs
@@ -120,7 +120,7 @@ pub fn object(input: TokenStream) -> TokenStream {
     let setter_builder_impl = generate_setter_builder_methods(struct_name, &processed);
     let default_impl =
         should_generate_default.then(|| generate_default_impl(struct_name, &processed)).unwrap_or_default();
-    let inspect_impl = generate_inspect_impl(struct_name, &processed);
+    let inspect_impl = generate_inspect_impl(struct_name, &processed, &rustc_commit);
     let referenced_objects = find_referenced_object_types(&struct_item, &impl_blocks);
 
     // Collect all objects and custom types transitively

--- a/hotline-macros/src/lib.rs
+++ b/hotline-macros/src/lib.rs
@@ -14,7 +14,9 @@ mod utils;
 
 use codegen::core::generate_core_functions;
 use codegen::custom_types::generate_custom_type_proxies_for_types;
-use codegen::fields::{generate_default_impl, generate_field_accessors, generate_setter_builder_methods};
+use codegen::fields::{
+    generate_default_impl, generate_field_accessors, generate_inspect_impl, generate_setter_builder_methods,
+};
 use codegen::methods::generate_method_wrappers;
 use codegen::process_struct_attributes;
 use codegen::wrapper::generate_typed_wrappers;
@@ -118,6 +120,7 @@ pub fn object(input: TokenStream) -> TokenStream {
     let setter_builder_impl = generate_setter_builder_methods(struct_name, &processed);
     let default_impl =
         should_generate_default.then(|| generate_default_impl(struct_name, &processed)).unwrap_or_default();
+    let inspect_impl = generate_inspect_impl(struct_name, &processed);
     let referenced_objects = find_referenced_object_types(&struct_item, &impl_blocks);
 
     // Collect all objects and custom types transitively
@@ -283,6 +286,7 @@ pub fn object(input: TokenStream) -> TokenStream {
         #(#method_wrappers)*
         #core_functions
         #additional_wrappers
+        #inspect_impl
     };
 
     TokenStream::from(output)

--- a/hotline/src/lib.rs
+++ b/hotline/src/lib.rs
@@ -143,3 +143,8 @@ impl<T> Clone for ObjectRef<T> {
         Self { inner: self.inner.clone(), _phantom: PhantomData }
     }
 }
+
+/// Trait for objects that can provide their field values as strings.
+pub trait Inspectable {
+    fn fields(&mut self) -> Vec<(String, String)>;
+}

--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -470,19 +470,6 @@ hotline::object!({
     }
 });
 
-impl hotline::Inspectable for Rect {
-    fn fields(&mut self) -> Vec<(String, String)> {
-        let (x, y, w, h) = self.bounds();
-        vec![
-            ("x".into(), format!("{:.1}", x)),
-            ("y".into(), format!("{:.1}", y)),
-            ("width".into(), format!("{:.1}", w)),
-            ("height".into(), format!("{:.1}", h)),
-            ("rotation".into(), format!("{:.2}", self.rotation())),
-        ]
-    }
-}
-
 #[cfg(target_os = "linux")]
 fn save_png(path: &str, width: u32, height: u32, data: &[u8]) -> Result<(), String> {
     let file = File::create(path).map_err(|e| e.to_string())?;

--- a/objects/ObjectInspector/Cargo.toml
+++ b/objects/ObjectInspector/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2024"
+name = "ObjectInspector"
+version = "0.1.0"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }
+# do not add additional dependencies here

--- a/objects/ObjectInspector/src/lib.rs
+++ b/objects/ObjectInspector/src/lib.rs
@@ -22,6 +22,9 @@ hotline::object!({
         }
 
         fn ensure_renderers(&mut self) {
+            if let Some(registry) = self.get_registry() {
+                ::hotline::set_library_registry(registry);
+            }
             if self.title_renderer.is_none() {
                 self.title_renderer = Some(TextRenderer::new());
             }

--- a/objects/ObjectInspector/src/lib.rs
+++ b/objects/ObjectInspector/src/lib.rs
@@ -1,0 +1,54 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Default)]
+    pub struct ObjectInspector {
+        rect: Option<Rect>,
+        renderers: Vec<TextRenderer>,
+        title_renderer: Option<TextRenderer>,
+        fields: Vec<(String, String)>,
+        title: String,
+    }
+
+    impl ObjectInspector {
+        pub fn set_rect(&mut self, rect: Rect) {
+            self.rect = Some(rect);
+        }
+
+        pub fn inspect(&mut self, name: &str, fields: Vec<(String, String)>) {
+            self.title = name.to_string();
+            self.fields = fields;
+            self.ensure_renderers();
+        }
+
+        fn ensure_renderers(&mut self) {
+            if self.title_renderer.is_none() {
+                self.title_renderer = Some(TextRenderer::new());
+            }
+            while self.renderers.len() < self.fields.len() {
+                self.renderers.push(TextRenderer::new());
+            }
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], bw: i64, bh: i64, pitch: i64) {
+            if let Some(ref mut rect) = self.rect {
+                let (x, y, _, _) = rect.bounds();
+                if let Some(ref mut title) = self.title_renderer {
+                    title.set_text(self.title.clone());
+                    title.set_x(x + 5.0);
+                    title.set_y(y + 5.0);
+                    title.render(buffer, bw, bh, pitch);
+                }
+
+                for (i, (name, value)) in self.fields.iter().enumerate() {
+                    if let Some(tr) = self.renderers.get_mut(i) {
+                        tr.set_text(format!("{}: {}", name, value));
+                        tr.set_x(x + 5.0);
+                        tr.set_y(y + 25.0 + i as f64 * 14.0);
+                        tr.render(buffer, bw, bh, pitch);
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- generate Inspectable implementation in object macro
- remove manual impls from Rect and RegularPolygon
- keep inspector access via wrapper in Application

## Testing
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_6844136fe97c8325a4c3fd0ccfa7736e