### PR TITLE
Fix autonomy checkbox hit-test scaling

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -235,7 +235,7 @@ hotline::object!({
                                 }
                             }
                             if let Some(ref mut cb) = self.autonomy_checkbox {
-                                cb.handle_mouse_down(x as f64, y as f64);
+                                cb.handle_mouse_down(adj_x, adj_y);
                             }
                         }
                         Event::MouseButtonDown { mouse_btn: MouseButton::Right, x, y, .. } => {


### PR DESCRIPTION
## Summary
- pass scaled coordinates to autonomy checkbox hit-test

## Testing
- `cargo build --all --release`
- `cargo run --bin runtime --release` *(fails: cannot find -lSDL3)*

------
https://chatgpt.com/codex/tasks/task_e_68459825510083259aaac814e6f5f59a