### PR TITLE
Close inspector when deselecting

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -220,7 +220,9 @@ hotline::object!({
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_down(adj_x, adj_y);
                                 let hits = wm.inspect_click(adj_x, adj_y);
-                                if !hits.is_empty() {
+                                if hits.is_empty() {
+                                    wm.close_inspector();
+                                } else {
                                     wm.open_inspector(hits);
                                 }
                             }


### PR DESCRIPTION
## Summary
- hide the inspector when clicking empty space in the window manager

## Testing
- `cargo build --all --release` *(fails: cannot find -lSDL3)*
- `cargo run --bin runtime --release` *(fails: previous build error)*

------
https://chatgpt.com/codex/tasks/task_e_6845a7a3db48832586329323d44b17ff