### PR TITLE
Add render time overlay toggle

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -24,6 +24,7 @@ hotline::object!({
         gpu_commands: Vec<RenderCommand>,
         fps_counter: Option<TextRenderer>,
         autonomy_checkbox: Option<Checkbox>,
+        render_time_checkbox: Option<Checkbox>,
         frame_times: std::collections::VecDeque<std::time::Instant>,
         last_fps_update: Option<std::time::Instant>,
         current_fps: f64,
@@ -94,6 +95,16 @@ hotline::object!({
                 r_ref.initialize(20.0, 60.0, 20.0, 20.0);
                 cb.set_rect(rect);
                 cb.set_label("Autonomy".to_string());
+            }
+
+            // Create render time checkbox
+            self.render_time_checkbox = Some(Checkbox::new());
+            if let Some(ref mut cb) = self.render_time_checkbox {
+                let rect = Rect::new();
+                let mut r_ref = rect.clone();
+                r_ref.initialize(20.0, 90.0, 20.0, 20.0);
+                cb.set_rect(rect);
+                cb.set_label("Render Times".to_string());
             }
 
             // Create FPS counter
@@ -237,6 +248,9 @@ hotline::object!({
                                 }
                             }
                             if let Some(ref mut cb) = self.autonomy_checkbox {
+                                cb.handle_mouse_down(adj_x, adj_y);
+                            }
+                            if let Some(ref mut cb) = self.render_time_checkbox {
                                 cb.handle_mouse_down(adj_x, adj_y);
                             }
                         }
@@ -429,6 +443,9 @@ hotline::object!({
                         wm.update_autonomy(self.mouse_x, self.mouse_y);
                     }
                 }
+                if let (Some(wm), Some(cb)) = (&mut self.window_manager, &mut self.render_time_checkbox) {
+                    wm.set_show_render_times(cb.checked());
+                }
 
                 // Render
                 self.render_frame(&mut texture)?;
@@ -491,6 +508,9 @@ hotline::object!({
                     }
 
                     if let Some(ref mut cb) = self.autonomy_checkbox {
+                        cb.render(buffer, 800, 600, pitch as i64);
+                    }
+                    if let Some(ref mut cb) = self.render_time_checkbox {
                         cb.render(buffer, 800, 600, pitch as i64);
                     }
 

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -32,6 +32,9 @@ hotline::object!({
         context_menu: Option<ContextMenu>,
         polygon_menu: Option<PolygonMenu>,
         click_inspector: Option<ClickInspector>,
+        show_render_times: bool,
+        rect_time_labels: Vec<TextRenderer>,
+        polygon_time_labels: Vec<TextRenderer>,
         dragging: bool,
         drag_offset_x: f64,
         drag_offset_y: f64,
@@ -431,6 +434,24 @@ hotline::object!({
             self.context_menu = Some(menu);
         }
 
+        pub fn set_show_render_times(&mut self, show: bool) {
+            self.show_render_times = show;
+        }
+
+        fn ensure_time_renderers(&mut self) {
+            if self.show_render_times {
+                if let Some(registry) = self.get_registry() {
+                    ::hotline::set_library_registry(registry);
+                }
+                if self.rect_time_labels.len() != self.rects.len() {
+                    self.rect_time_labels.resize_with(self.rects.len(), TextRenderer::new);
+                }
+                if self.polygon_time_labels.len() != self.polygons.len() {
+                    self.polygon_time_labels.resize_with(self.polygons.len(), TextRenderer::new);
+                }
+            }
+        }
+
         pub fn update_autonomy(&mut self, mouse_x: f64, mouse_y: f64) {
             for mover in &mut self.rect_movers {
                 mover.update(mouse_x, mouse_y);
@@ -438,14 +459,40 @@ hotline::object!({
         }
 
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {
+            self.ensure_time_renderers();
+
             // Render all rects
-            for rect_handle in &mut self.rects {
+            for (i, rect_handle) in self.rects.iter_mut().enumerate() {
+                let start = std::time::Instant::now();
                 rect_handle.render(buffer, buffer_width, buffer_height, pitch);
+                if self.show_render_times {
+                    let us = start.elapsed().as_micros();
+                    if let Some(label) = self.rect_time_labels.get_mut(i) {
+                        label.set_text(format!("{}us", us));
+                        let (x, y, _w, _h) = rect_handle.bounds();
+                        let lh = label.line_height();
+                        label.set_x(x);
+                        label.set_y(y - lh);
+                        label.render(buffer, buffer_width, buffer_height, pitch);
+                    }
+                }
             }
 
             // Render polygons
-            for poly in &mut self.polygons {
+            for (i, poly) in self.polygons.iter_mut().enumerate() {
+                let start = std::time::Instant::now();
                 poly.render(buffer, buffer_width, buffer_height, pitch);
+                if self.show_render_times {
+                    let us = start.elapsed().as_micros();
+                    if let Some(label) = self.polygon_time_labels.get_mut(i) {
+                        label.set_text(format!("{}us", us));
+                        let (x, y, _w, _h) = poly.bounds();
+                        let lh = label.line_height();
+                        label.set_x(x);
+                        label.set_y(y - lh);
+                        label.render(buffer, buffer_width, buffer_height, pitch);
+                    }
+                }
             }
 
             // Render the highlight lens if we have one (this will render the selected rect with highlight)


### PR DESCRIPTION
## Summary
- add new checkbox to toggle render time display
- instrument WindowManager to measure and render per-object render microseconds

## Testing
- `cargo build --all --release` *(fails: cannot find -lSDL3)*
- `cargo run --bin runtime --release` *(fails: cannot find -lSDL3)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa45fd4c8325acc2271e24d857c7