### PR TITLE
Add popup file menu to CodeEditor

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -268,8 +268,18 @@ hotline::object!({
                             let adj_x = x as f64 * scale_x / self.pixel_multiple as f64;
                             let adj_y = y as f64 * scale_y / self.pixel_multiple as f64;
 
-                            if let Some(ref mut wm) = self.window_manager {
-                                wm.handle_right_click(adj_x, adj_y);
+                            let mut consumed = false;
+                            if let Some(ref mut editor) = self.code_editor {
+                                if editor.contains_point(adj_x, adj_y) {
+                                    let _ = editor.open_file_menu(adj_x, adj_y);
+                                    consumed = true;
+                                }
+                            }
+
+                            if !consumed {
+                                if let Some(ref mut wm) = self.window_manager {
+                                    wm.handle_right_click(adj_x, adj_y);
+                                }
                             }
                             self.mouse_x = x as f64;
                             self.mouse_y = y as f64;

--- a/objects/ContextMenu/src/lib.rs
+++ b/objects/ContextMenu/src/lib.rs
@@ -33,8 +33,30 @@ hotline::object!({
             self.visible = true;
         }
 
+        pub fn open_with_items(&mut self, items: Vec<String>, x: f64, y: f64) {
+            self.set_items(items);
+            self.x = x;
+            self.y = y;
+            self.visible = true;
+        }
+
         pub fn close(&mut self) {
             self.visible = false;
+        }
+
+        pub fn set_items(&mut self, items: Vec<String>) {
+            self.items = items;
+            self.renderers.clear();
+            if let Some(registry) = self.get_registry() {
+                ::hotline::set_library_registry(registry);
+            }
+            for item in &self.items {
+                self.renderers.push(TextRenderer::new().with_text(item.clone()).with_color((255, 255, 255, 255)));
+            }
+        }
+
+        pub fn is_visible(&self) -> bool {
+            self.visible
         }
 
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> Option<String> {


### PR DESCRIPTION
## Summary
- allow CodeEditor to open a popup menu of available objects
- support dynamic items in ContextMenu
- open file menu on right-click inside editor

## Testing
- `cargo build --all --release` *(fails: ld returned 1 exit status)*
- `cargo run --bin runtime --release` *(fails: could not compile `Application`)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9b1c4a083259b419eaad3482fab