### PR TITLE
Improve code editor input handling

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -333,6 +333,14 @@ hotline::object!({
                                 }
                             }
                         }
+                        Event::KeyDown { keycode: Some(Keycode::Return), .. }
+                        | Event::KeyDown { keycode: Some(Keycode::KpEnter), .. } => {
+                            if let Some(ref mut editor) = self.code_editor {
+                                if editor.is_focused() {
+                                    editor.insert_newline();
+                                }
+                            }
+                        }
                         Event::KeyDown { keycode: Some(Keycode::Left), keymod, .. } => {
                             if let Some(ref mut editor) = self.code_editor {
                                 if editor.is_focused() {
@@ -370,8 +378,16 @@ hotline::object!({
                             }
                         }
                         Event::KeyDown { keycode: Some(Keycode::R), .. } => {
-                            if let Some(ref mut wm) = self.window_manager {
-                                wm.rotate_selected(0.1);
+                            let mut editing = false;
+                            if let Some(ref mut editor) = self.code_editor {
+                                if editor.is_focused() {
+                                    editing = true;
+                                }
+                            }
+                            if !editing {
+                                if let Some(ref mut wm) = self.window_manager {
+                                    wm.rotate_selected(0.1);
+                                }
                             }
                         }
                         Event::KeyDown { keycode: Some(Keycode::Equals), keymod, .. }

--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -168,6 +168,10 @@ hotline::object!({
             }
         }
 
+        pub fn insert_newline(&mut self) {
+            self.insert_char('\n');
+        }
+
         pub fn backspace(&mut self) {
             if self.focused {
                 if let Some((s, e)) = self.selection.take() {


### PR DESCRIPTION
## Summary
- add `insert_newline` to `CodeEditor`
- support Return and KP Enter keys in the code editor
- ignore R key for rotation when editor has focus

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_684650c13fcc8325bf0300b188c2a936