### PR TITLE
Add draggable click inspector

### DIFF
--- a/objects/ClickInspector/src/lib.rs
+++ b/objects/ClickInspector/src/lib.rs
@@ -9,6 +9,9 @@ hotline::object!({
         x: f64,
         #[default(10.0)]
         y: f64,
+        dragging: bool,
+        drag_offset_x: f64,
+        drag_offset_y: f64,
         visible: bool,
     }
 
@@ -37,6 +40,37 @@ hotline::object!({
 
         pub fn close(&mut self) {
             self.visible = false;
+        }
+
+        pub fn is_dragging(&self) -> bool {
+            self.dragging
+        }
+
+        pub fn handle_mouse_down(&mut self, x: f64, y: f64) -> bool {
+            if !self.visible {
+                return false;
+            }
+            let item_height = 16.0;
+            let width = 200.0;
+            let height = item_height * self.items.len() as f64;
+            if x >= self.x && x <= self.x + width && y >= self.y && y <= self.y + height {
+                self.dragging = true;
+                self.drag_offset_x = x - self.x;
+                self.drag_offset_y = y - self.y;
+                return true;
+            }
+            false
+        }
+
+        pub fn handle_mouse_up(&mut self) {
+            self.dragging = false;
+        }
+
+        pub fn handle_mouse_move(&mut self, x: f64, y: f64) {
+            if self.dragging {
+                self.x = x - self.drag_offset_x;
+                self.y = y - self.drag_offset_y;
+            }
         }
 
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -159,6 +159,11 @@ hotline::object!({
         }
 
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) {
+            if let Some(ref mut inspector) = self.click_inspector {
+                if inspector.handle_mouse_down(x, y) {
+                    return;
+                }
+            }
             if let Some(ref mut pm) = self.polygon_menu {
                 if pm.is_visible() {
                     if let Some(sides) = pm.handle_mouse_down(x, y) {
@@ -297,6 +302,13 @@ hotline::object!({
         }
 
         pub fn handle_mouse_up(&mut self, x: f64, y: f64) {
+            if let Some(ref mut inspector) = self.click_inspector {
+                let was_dragging = inspector.is_dragging();
+                inspector.handle_mouse_up();
+                if was_dragging {
+                    return;
+                }
+            }
             if self.context_menu.is_some() {
                 return;
             } else if self.resizing {
@@ -326,6 +338,12 @@ hotline::object!({
         }
 
         pub fn handle_mouse_motion(&mut self, x: f64, y: f64) {
+            if let Some(ref mut inspector) = self.click_inspector {
+                inspector.handle_mouse_move(x, y);
+                if inspector.is_dragging() {
+                    return;
+                }
+            }
             if let Some(ref mut pm) = self.polygon_menu {
                 if pm.is_visible() {
                     pm.handle_mouse_move(x, y);


### PR DESCRIPTION
## Summary
- allow dragging ClickInspector with mouse
- forward input events in WindowManager

## Testing
- `cargo build --all --release`
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_68465119144c832592ba5acfd9021b06