### PR TITLE
Fix unreachable event loop on Linux

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -174,6 +174,7 @@ hotline::object!({
                 return Ok(());
             }
 
+            #[cfg_attr(target_os = "linux", allow(unreachable_code))]
             'running: loop {
                 // Track frame time
                 let now = std::time::Instant::now();


### PR DESCRIPTION
## Summary
- ensure application event loop compiles on Linux
- allow unreachable code warning only on Linux

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_6846509bec8c832598200d54d2dbc490