### PR TITLE
Enable drag-selection in CodeEditor

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -287,6 +287,9 @@ hotline::object!({
                             if let Some(ref mut wheel) = self.color_wheel {
                                 wheel.handle_mouse_up();
                             }
+                            if let Some(ref mut editor) = self.code_editor {
+                                editor.handle_mouse_up();
+                            }
                             self.mouse_x = x as f64;
                             self.mouse_y = y as f64;
                         }
@@ -299,6 +302,9 @@ hotline::object!({
 
                             if let Some(ref mut wm) = self.window_manager {
                                 wm.handle_mouse_motion(adj_x, adj_y);
+                            }
+                            if let Some(ref mut editor) = self.code_editor {
+                                editor.handle_mouse_move(adj_x, adj_y);
                             }
                             if let Some(ref mut wheel) = self.color_wheel {
                                 if let Some(color) = wheel.handle_mouse_move(adj_x, adj_y) {


### PR DESCRIPTION
## Summary
- allow drag-selection in CodeEditor widget
- forward mouse move/up events from Application to CodeEditor

## Testing
- `cargo build --all --release`
- `cargo run --bin runtime --release` *(fails: `libSDL3.so.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684654a6204c8325859faf548a8691ef