### PR TITLE
Adjust click inspector default position

### DIFF
--- a/objects/ClickInspector/src/lib.rs
+++ b/objects/ClickInspector/src/lib.rs
@@ -7,7 +7,7 @@ hotline::object!({
         renderers: Vec<TextRenderer>,
         #[default(10.0)]
         x: f64,
-        #[default(10.0)]
+        #[default(120.0)]
         y: f64,
         dragging: bool,
         drag_offset_x: f64,


### PR DESCRIPTION
## Summary
- place the click inspector below the checkboxes

## Testing
- `cargo run --bin runtime --release > /tmp/test.log 2>&1; tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6846591f4d4c8325826bfdac7e40fa6b