### PR TITLE
Fix highlight lens line rendering

### DIFF
--- a/objects/HighlightLens/src/lib.rs
+++ b/objects/HighlightLens/src/lib.rs
@@ -28,7 +28,7 @@ hotline::object!({
         ) {
             let dx = x1 - x0;
             let dy = y1 - y0;
-            let steps = dx.abs().max(dy.abs()) as i64;
+            let steps = dx.abs().max(dy.abs()).ceil() as i64;
             if steps == 0 {
                 return;
             }


### PR DESCRIPTION
## Summary
- avoid truncating line steps in `HighlightLens` line drawing

## Testing
- `cargo build --all --release`
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_6846595876608325bacaab2ad93b9106