### PR TITLE
Implement live-updating inspector

### DIFF
--- a/objects/ClickInspector/src/lib.rs
+++ b/objects/ClickInspector/src/lib.rs
@@ -38,8 +38,17 @@ hotline::object!({
             self.ensure_renderers();
         }
 
+        pub fn update_items(&mut self, items: Vec<String>) {
+            self.items = items;
+            self.ensure_renderers();
+        }
+
         pub fn close(&mut self) {
             self.visible = false;
+        }
+
+        pub fn is_visible(&self) -> bool {
+            self.visible
         }
 
         pub fn is_dragging(&self) -> bool {

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -137,6 +137,18 @@ hotline::object!({
             }
         }
 
+        fn update_inspector(&mut self) {
+            if let (Some(ref mut inspector), Some(sel)) = (self.click_inspector.as_mut(), self.selected) {
+                if inspector.is_visible() {
+                    let items = match sel {
+                        SelectedObject::Rect(i) => self.rects[i].info_lines(),
+                        SelectedObject::Polygon(i) => self.polygons[i].info_lines(),
+                    };
+                    inspector.update_items(items);
+                }
+            }
+        }
+
         pub fn get_selected_handle(&mut self) -> Option<SelectedObject> {
             self.selected
         }
@@ -355,6 +367,7 @@ hotline::object!({
                         }
                     }
                     self.update_highlight();
+                    self.update_inspector();
                 }
             } else if self.resizing {
                 if let (Some(sel), Some((start_x, start_y)), Some((orig_x, orig_y, orig_w, orig_h))) =
@@ -421,6 +434,7 @@ hotline::object!({
                         }
                     }
                     self.update_highlight();
+                    self.update_inspector();
                 }
             }
         }
@@ -438,6 +452,7 @@ hotline::object!({
                     }
                 }
                 self.update_highlight();
+                self.update_inspector();
             }
         }
 
@@ -472,6 +487,7 @@ hotline::object!({
             for mover in &mut self.rect_movers {
                 mover.update(mouse_x, mouse_y);
             }
+            self.update_inspector();
         }
 
         pub fn render(&mut self, buffer: &mut [u8], buffer_width: i64, buffer_height: i64, pitch: i64) {


### PR DESCRIPTION
## Summary
- refresh inspector data when objects move, resize or rotate
- expose helper methods on `ClickInspector`

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_6846597d01e483258a11c10408114d42