### PR TITLE
Enable momentum scrolling in CodeEditor

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -330,7 +330,7 @@ hotline::object!({
                         Event::MouseWheel { y, .. } => {
                             if let Some(ref mut editor) = self.code_editor {
                                 if editor.is_focused() {
-                                    editor.scroll_by(-y as f64 * 20.0);
+                                    editor.add_scroll_velocity(-y as f64 * 20.0);
                                 }
                             }
                         }
@@ -485,6 +485,9 @@ hotline::object!({
                 }
                 if let (Some(wm), Some(cb)) = (&mut self.window_manager, &mut self.render_time_checkbox) {
                     wm.set_show_render_times(cb.checked());
+                }
+                if let Some(ref mut editor) = self.code_editor {
+                    editor.update_scroll();
                 }
 
                 // Render

--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -20,6 +20,8 @@ hotline::object!({
         #[setter]
         #[default(0.0)]
         scroll_offset: f64,
+        #[default(0.0)]
+        scroll_velocity: f64,
         file_menu: Option<ContextMenu>,
     }
 
@@ -322,6 +324,19 @@ hotline::object!({
                 let total_height = self.text.lines().count() as f64 * line_height;
                 let max_offset = (total_height - rect.bounds().3).max(0.0);
                 self.scroll_offset = (self.scroll_offset + delta).max(0.0).min(max_offset);
+            }
+        }
+
+        pub fn add_scroll_velocity(&mut self, delta: f64) {
+            self.scroll_velocity += delta;
+        }
+
+        pub fn update_scroll(&mut self) {
+            if self.scroll_velocity.abs() > 0.1 {
+                self.scroll_by(self.scroll_velocity);
+                self.scroll_velocity *= 0.85;
+            } else {
+                self.scroll_velocity = 0.0;
             }
         }
 


### PR DESCRIPTION
## Summary
- add `scroll_velocity` state to `CodeEditor`
- implement `add_scroll_velocity` and `update_scroll` to apply inertia
- use momentum updates in application mouse wheel events
- update main loop to call `update_scroll` every frame

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`


------
https://chatgpt.com/codex/tasks/task_e_6846599ea55c83259666d7c763cb0897