### PR TITLE
Improve CodeEditor drag detection

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -234,19 +234,22 @@ hotline::object!({
                             let adj_x = x as f64 * scale_x / self.pixel_multiple as f64;
                             let adj_y = y as f64 * scale_y / self.pixel_multiple as f64;
 
-                            if let Some(ref mut wm) = self.window_manager {
-                                wm.handle_mouse_down(adj_x, adj_y);
-                                let hits = wm.inspect_click(adj_x, adj_y);
-                                if hits.is_empty() {
-                                    wm.close_inspector();
-                                } else {
-                                    wm.open_inspector(hits);
-                                }
-                            }
                             self.mouse_x = x as f64;
                             self.mouse_y = y as f64;
+                            let mut consumed = false;
                             if let Some(ref mut editor) = self.code_editor {
-                                editor.handle_mouse_down(adj_x, adj_y);
+                                consumed = editor.handle_mouse_down(adj_x, adj_y);
+                            }
+                            if !consumed {
+                                if let Some(ref mut wm) = self.window_manager {
+                                    wm.handle_mouse_down(adj_x, adj_y);
+                                    let hits = wm.inspect_click(adj_x, adj_y);
+                                    if hits.is_empty() {
+                                        wm.close_inspector();
+                                    } else {
+                                        wm.open_inspector(hits);
+                                    }
+                                }
                             }
                             if let Some(ref mut wheel) = self.color_wheel {
                                 if let Some(color) = wheel.handle_mouse_down(adj_x, adj_y) {


### PR DESCRIPTION
## Summary
- allow CodeEditor mouse_down to return whether the click was on text
- when clicking inside the editor, decide to drag the window or select text
- avoid starting a window drag when text selection begins

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_684659bcd1208325b9b7e896980ab9e4