### PR TITLE
Keep inspector open when resizing

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -238,7 +238,13 @@ hotline::object!({
                                 wm.handle_mouse_down(adj_x, adj_y);
                                 let hits = wm.inspect_click(adj_x, adj_y);
                                 if hits.is_empty() {
-                                    wm.close_inspector();
+                                    if wm.is_resizing() {
+                                        if let Some(items) = wm.selected_info_lines() {
+                                            wm.open_inspector(items);
+                                        }
+                                    } else {
+                                        wm.close_inspector();
+                                    }
                                 } else {
                                     wm.open_inspector(hits);
                                 }

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -169,6 +169,18 @@ hotline::object!({
             self.dragging
         }
 
+        pub fn is_resizing(&self) -> bool {
+            self.resizing
+        }
+
+        pub fn selected_info_lines(&mut self) -> Option<Vec<String>> {
+            match self.selected {
+                Some(SelectedObject::Rect(i)) => Some(self.rects[i].info_lines()),
+                Some(SelectedObject::Polygon(i)) => Some(self.polygons[i].info_lines()),
+                None => None,
+            }
+        }
+
         pub fn handle_mouse_down(&mut self, x: f64, y: f64) {
             if let Some(ref mut inspector) = self.click_inspector {
                 if inspector.handle_mouse_down(x, y) {


### PR DESCRIPTION
## Summary
- add `is_resizing` and `selected_info_lines` helpers
- keep inspector open if resizing a selected object

## Testing
- `cargo build --all --release && cargo run --bin runtime --release`


------
https://chatgpt.com/codex/tasks/task_e_68465b4585b88325892c2890d2430b8b