### PR TITLE
Show path-relative filename

### DIFF
--- a/objects/CodeEditor/src/lib.rs
+++ b/objects/CodeEditor/src/lib.rs
@@ -141,7 +141,15 @@ hotline::object!({
         pub fn open(&mut self, path: &str) -> Result<(), String> {
             self.text = std::fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path, e))?;
             self.file_path = Some(path.to_string());
-            self.file_name = std::path::Path::new(path).file_name().map(|s| s.to_string_lossy().into_owned());
+
+            // Display path relative to the objects directory if possible
+            let p = std::path::Path::new(path);
+            self.file_name = p
+                .strip_prefix("objects")
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+                .or_else(|| p.file_name().map(|s| s.to_string_lossy().into_owned()));
+
             self.initialize();
             Ok(())
         }


### PR DESCRIPTION
## Summary
- show filename relative to the `objects` directory when opening a file in the `CodeEditor`

## Testing
- `cargo build --all --release`
- `cargo run --bin runtime --release`

------
https://chatgpt.com/codex/tasks/task_e_68465ea6c9908325b120c0540e18c500