### PR TITLE
Add image object with drag-and-drop support

### DIFF
--- a/objects/Application/src/lib.rs
+++ b/objects/Application/src/lib.rs
@@ -493,6 +493,25 @@ hotline::object!({
                                 }
                             }
                         }
+                        Event::DropFile { filename, .. } => {
+                            if filename.to_lowercase().ends_with(".png") {
+                                let (win_w, win_h) = canvas.window().size();
+                                let scale_x = self.width as f64 / win_w as f64;
+                                let scale_y = self.height as f64 / win_h as f64;
+                                let adj_x = self.mouse_x * scale_x / self.pixel_multiple as f64;
+                                let adj_y = self.mouse_y * scale_y / self.pixel_multiple as f64;
+
+                                if let Some(ref mut wm) = self.window_manager {
+                                    if let Some(registry) = wm.get_registry() {
+                                        ::hotline::set_library_registry(registry);
+                                    }
+                                    let mut img = Image::new();
+                                    img.initialize(adj_x, adj_y);
+                                    img.load_png(&filename)?;
+                                    wm.add_image(img);
+                                }
+                            }
+                        }
                         _ => {}
                     }
                 }

--- a/objects/Image/Cargo.toml
+++ b/objects/Image/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Image"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+hotline = { path = "../../hotline" }

--- a/objects/Image/src/lib.rs
+++ b/objects/Image/src/lib.rs
@@ -1,0 +1,74 @@
+use hotline::HotlineObject;
+
+hotline::object!({
+    #[derive(Clone, Default)]
+    pub struct Image {
+        #[default(0.0)]
+        x: f64,
+        #[default(0.0)]
+        y: f64,
+        width: u32,
+        height: u32,
+        data: Vec<u8>,
+    }
+
+    impl Image {
+        pub fn initialize(&mut self, x: f64, y: f64) {
+            self.x = x;
+            self.y = y;
+        }
+
+        fn load_from_loader(&mut self, loader: &mut PNGLoader) -> Result<(), String> {
+            if let Some((data, width, height)) = loader.data() {
+                self.width = width;
+                self.height = height;
+                // Convert from RGBA to BGRA
+                self.data = data.chunks_exact(4).flat_map(|px| [px[2], px[1], px[0], px[3]]).collect();
+                Ok(())
+            } else {
+                Err("PNG data not available".to_string())
+            }
+        }
+
+        pub fn load_png(&mut self, path: &str) -> Result<(), String> {
+            if let Some(registry) = self.get_registry() {
+                ::hotline::set_library_registry(registry);
+            }
+            let mut loader = PNGLoader::new();
+            loader.load_png(path)?;
+            self.load_from_loader(&mut loader)
+        }
+
+        pub fn load_png_bytes(&mut self, data: &[u8]) -> Result<(), String> {
+            if let Some(registry) = self.get_registry() {
+                ::hotline::set_library_registry(registry);
+            }
+            let mut loader = PNGLoader::new();
+            loader.load_png_bytes(data)?;
+            self.load_from_loader(&mut loader)
+        }
+
+        pub fn render(&mut self, buffer: &mut [u8], bw: i64, bh: i64, pitch: i64) {
+            let x_start = self.x.max(0.0) as i64;
+            let y_start = self.y.max(0.0) as i64;
+            let x_end = (self.x + self.width as f64).min(bw as f64) as i64;
+            let y_end = (self.y + self.height as f64).min(bh as f64) as i64;
+
+            for y in y_start..y_end {
+                for x in x_start..x_end {
+                    let src_x = (x - self.x as i64) as usize;
+                    let src_y = (y - self.y as i64) as usize;
+                    let src_off = (src_y * self.width as usize + src_x) * 4;
+                    let dst_off = (y * pitch as i64 + x * 4) as usize;
+                    if src_off + 3 < self.data.len() && dst_off + 3 < buffer.len() {
+                        buffer[dst_off..dst_off + 4].copy_from_slice(&self.data[src_off..src_off + 4]);
+                    }
+                }
+            }
+        }
+
+        pub fn bounds(&mut self) -> (f64, f64, f64, f64) {
+            (self.x, self.y, self.width as f64, self.height as f64)
+        }
+    }
+});

--- a/objects/WindowManager/src/lib.rs
+++ b/objects/WindowManager/src/lib.rs
@@ -26,6 +26,7 @@ hotline::object!({
         rects: Vec<Rect>,
         rect_movers: Vec<RectMover>,
         polygons: Vec<RegularPolygon>,
+        images: Vec<Image>,
         selected: Option<SelectedObject>,
         highlight_lens: Option<HighlightLens>, // HighlightLens for selected rect
         text_renderer: Option<TextRenderer>,   // TextRenderer for displaying text
@@ -72,6 +73,10 @@ hotline::object!({
             mover.set_target(rect.clone());
             self.rect_movers.push(mover);
             self.rects.push(rect);
+        }
+
+        pub fn add_image(&mut self, image: Image) {
+            self.images.push(image);
         }
 
         pub fn inspect_click(&mut self, x: f64, y: f64) -> Vec<String> {
@@ -537,6 +542,11 @@ hotline::object!({
                         label.render(buffer, buffer_width, buffer_height, pitch);
                     }
                 }
+            }
+
+            // Render images
+            for image in &mut self.images {
+                image.render(buffer, buffer_width, buffer_height, pitch);
             }
 
             // Render the highlight lens if we have one (this will render the selected rect with highlight)


### PR DESCRIPTION
## Summary
- introduce an `Image` object for loading PNG files via `PNGLoader`
- allow dropping PNG files onto the application window to create images
- render `Image` instances from the `WindowManager`

## Testing
- `cargo build --all --release && cargo run --bin runtime --release` *(fails: libSDL3 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467b5e45bc832590c7eb9c5faa285c